### PR TITLE
Fix bug and responsive

### DIFF
--- a/src/app/dashboard/buyer/page.tsx
+++ b/src/app/dashboard/buyer/page.tsx
@@ -267,15 +267,15 @@ export default function BuyerDashboardPage() {
         <motion.div 
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          className="flex justify-between items-center mb-8"
+          className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8"
         >
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 text-center sm:text-left">
             Brand Dashboard
           </h1>
-          <div className="flex gap-4">
+          <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
             <Button 
               onClick={handleCreateTask}
-              className="bg-pink-600 hover:bg-pink-700 text-white shadow-sm hover:shadow-md transition-all duration-300"
+              className="w-full sm:w-auto bg-pink-600 hover:bg-pink-700 text-white shadow-sm hover:shadow-md transition-all duration-300"
             >
               Create New Task
             </Button>
@@ -283,7 +283,7 @@ export default function BuyerDashboardPage() {
               variant="outline" 
               onClick={handleLogout}
               disabled={isLoading}
-              className="border-gray-200 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-900"
+              className="w-full sm:w-auto border-gray-200 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-900"
             >
               {isLoading ? 'Logging out...' : 'Logout'}
             </Button>

--- a/src/app/dashboard/influencer/page.tsx
+++ b/src/app/dashboard/influencer/page.tsx
@@ -447,15 +447,15 @@ export default function InfluencerDashboardPage() {
         <motion.div 
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          className="flex justify-between items-center mb-8"
+          className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8"
         >
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 text-center sm:text-left">
             Influencer Dashboard
           </h1>
-          <div className="flex gap-4">
+          <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
             <Link href="/dashboard/influencer/platforms">
               <Button 
-                className="bg-pink-600 hover:bg-pink-700 text-white shadow-sm hover:shadow-md transition-all duration-300"
+                className="w-full sm:w-auto bg-pink-600 hover:bg-pink-700 text-white shadow-sm hover:shadow-md transition-all duration-300"
               >
                 Connect New Account
               </Button>
@@ -464,7 +464,7 @@ export default function InfluencerDashboardPage() {
               variant="outline" 
               onClick={handleLogout}
               disabled={isLoading}
-              className="border-gray-200 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-900"
+              className="w-full sm:w-auto border-gray-200 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-900"
             >
               {isLoading ? 'Logging out...' : 'Logout'}
             </Button>

--- a/src/components/dashboard/task-preview-modal.tsx
+++ b/src/components/dashboard/task-preview-modal.tsx
@@ -142,12 +142,23 @@ export function TaskPreviewModal({ task }: TaskPreviewModalProps) {
                 {task.total_influencers || 0} Influencers
               </div>
               <div className="flex items-center gap-2 text-pink-600 dark:text-pink-400 font-medium">
-                <span className="font-bold">
-                  Rs. {((cost?.amount * 63) / 100 || 0).toLocaleString()}
-                </span>
-                <span className="text-xs text-muted-foreground">
-                  Total Budget
-                </span>
+                {(() => {
+                  const lkrPerUsd = Number(process.env.NEXT_PUBLIC_LKR_PER_USD) || 295;
+                  const payoutLkr = ((cost?.amount || 0) * 63) / 100;
+                  const payoutUsd = payoutLkr / lkrPerUsd;
+                  return (
+                    <>
+                      <span className="font-bold">
+                        LKR {Math.round(payoutLkr).toLocaleString()}
+                      </span>
+                      <span className="text-muted-foreground">•</span>
+                      <span className="font-bold">
+                        $ {payoutUsd.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                      </span>
+                      <span className="text-xs text-muted-foreground">Total Budget</span>
+                    </>
+                  );
+                })()}
               </div>
               {earliestDeadline && (
                 <div className="flex items-center gap-2 text-pink-600 dark:text-pink-400 font-medium">

--- a/src/components/ui/tasks-section.tsx
+++ b/src/components/ui/tasks-section.tsx
@@ -139,16 +139,6 @@ function TaskCard({ task, index }: TaskCardProps) {
   // Animation delay based on index
   const delay = 0.1 + index * 0.1;
 
-  // Currency: 1 USD = NEXT_PUBLIC_LKR_PER_USD LKR
-  const LKR_PER_USD = Number(process.env.NEXT_PUBLIC_LKR_PER_USD ?? "295");
-  const LKR_TO_USD = 1 / (LKR_PER_USD || 295);
-  const formatUSD = (lkrAmount: number) =>
-    new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "USD",
-      maximumFractionDigits: 2,
-    }).format(lkrAmount * LKR_TO_USD);
-
   // Calculate progress percentage
   const progress =
     task.total_target_views && task.total_promised_views
@@ -268,9 +258,16 @@ function TaskCard({ task, index }: TaskCardProps) {
                 <span>{task.total_influencers || 0} Influencers</span>
               </span>
               <span className="flex items-center gap-2">
-                <span className="font-medium text-pink-600 dark:text-pink-400">
-                  {formatUSD(Number(task.cost?.amount || 0))}
-                </span>
+                {(() => {
+                  const lkrPerUsd = Number(process.env.NEXT_PUBLIC_LKR_PER_USD) || 295;
+                  const payoutLkr = (task.cost?.amount || 0) * 0.63;
+                  const payoutUsd = payoutLkr / lkrPerUsd;
+                  return (
+                    <span className="font-medium text-pink-600 dark:text-pink-400">
+                      $ {payoutUsd.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                    </span>
+                  );
+                })()}
               </span>
             </div>
 


### PR DESCRIPTION
This pull request improves the layout and currency display in both the buyer and influencer dashboards, as well as in task cards and modals. The main focus is on making the UI more responsive for different screen sizes and enhancing the clarity of budget information by showing both LKR and USD values.

**UI Responsiveness and Layout Improvements:**
- Updated dashboard header layouts in both `BuyerDashboardPage` and `InfluencerDashboardPage` to use a column layout on small screens and a row layout on larger screens. This ensures buttons and titles are stacked vertically on mobile and aligned horizontally on desktop, improving usability and appearance. [[1]](diffhunk://#diff-2298995c7a0c46a3fae1e1fedb7e3397bf26271f6d178beb42b91c2dc36fa76dL270-R286) [[2]](diffhunk://#diff-daa372efa155a99718702a6133ad03f3161b6550c78c51b863c7efe9994d5b5eL450-R458)
- Modified button classes in dashboard pages so that action buttons (e.g., "Create New Task", "Connect New Account", "Logout") expand to full width on small screens and revert to auto width on larger screens, enhancing mobile friendliness. [[1]](diffhunk://#diff-2298995c7a0c46a3fae1e1fedb7e3397bf26271f6d178beb42b91c2dc36fa76dL270-R286) [[2]](diffhunk://#diff-daa372efa155a99718702a6133ad03f3161b6550c78c51b863c7efe9994d5b5eL450-R458) [[3]](diffhunk://#diff-daa372efa155a99718702a6133ad03f3161b6550c78c51b863c7efe9994d5b5eL467-R467)

**Currency Display Enhancements:**
- In the `TaskPreviewModal`, replaced the static LKR budget display with a breakdown that shows both the payout in LKR and its equivalent in USD, using the `NEXT_PUBLIC_LKR_PER_USD` environment variable for conversion. This makes budget information clearer for users who prefer either currency.
- In the `TaskCard` component, replaced the previous USD formatting logic with an inline calculation that displays the payout in USD, improving consistency and removing redundant code. [[1]](diffhunk://#diff-b8d7c66136877153b7512f35ee4077d91262a178145fb3d4f20a5fd1a617f204L142-L151) [[2]](diffhunk://#diff-b8d7c66136877153b7512f35ee4077d91262a178145fb3d4f20a5fd1a617f204R261-R270)