### PR TITLE
Add BrandSync links, payments & admin flows

### DIFF
--- a/src/app/api/admin/brandsync-payments/[slipId]/route.ts
+++ b/src/app/api/admin/brandsync-payments/[slipId]/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabaseAdmin } from '@/lib/supabase-admin';
+import { sendMail } from '@/lib/utils/email';
+import { Database } from '@/types/database.types';
+
+export async function POST(req: NextRequest, { params }: { params: { slipId: string } }) {
+  try {
+    const slipId = Number(params.slipId);
+    if (!slipId) return NextResponse.json({ error: 'Invalid slip id' }, { status: 400 });
+
+    const body = await req.json();
+    const action = body.action as 'accept' | 'reject';
+    const reason = body.reason as string | undefined;
+
+    // Fetch slip and brandsync link
+    const { data: slip } = await supabaseAdmin
+      .from('brandsync_bank_transfer_slips')
+      .select('id, brandsync_id, slip_path, status, created_at')
+      .eq('id', slipId)
+      .single();
+
+    if (!slip) return NextResponse.json({ error: 'Slip not found' }, { status: 404 });
+
+    const { data: link } = await supabaseAdmin
+      .from('brandsync_links')
+      .select('id, user_id, title, amount')
+      .eq('id', slip.brandsync_id)
+      .single();
+
+    if (!link) return NextResponse.json({ error: 'BrandSync link not found' }, { status: 404 });
+
+    if (action === 'accept') {
+      // mark slip accepted and mark link as paid
+      const { error: u1 } = await supabaseAdmin
+        .from('brandsync_bank_transfer_slips')
+        .update({ status: 'ACCEPTED' })
+        .eq('id', slipId);
+      if (u1) throw u1;
+
+      const { error: u2 } = await supabaseAdmin
+        .from('brandsync_links')
+        .update({ is_paid: true })
+        .eq('id', link.id);
+      if (u2) throw u2;
+
+      // send email to buyer
+      const { data: profile } = await supabaseAdmin
+        .from('profile')
+        .select('email, name')
+        .eq('id', link.user_id)
+        .single();
+
+      if (profile?.email) {
+        await sendMail({
+          to: profile.email,
+          subject: 'Payment Accepted - BrandSync',
+          template: 'payment-accepted',
+          context: {
+            name: profile.name || 'User',
+            taskTitle: link.title || '',
+            taskId: String(link.id),
+            amount: String(link.amount || 0),
+            date: new Date().toISOString().split('T')[0]
+          },
+          from: 'accounts@brandsync.lk'
+        });
+      }
+
+      return NextResponse.json({ status: 'ok' });
+    } else {
+      // reject: mark slip rejected
+      const { error } = await supabaseAdmin
+        .from('brandsync_bank_transfer_slips')
+        .update({ status: 'REJECTED' })
+        .eq('id', slipId);
+      if (error) throw error;
+
+      // send rejection email
+      const { data: profile } = await supabaseAdmin
+        .from('profile')
+        .select('email, name')
+        .eq('id', link.user_id)
+        .single();
+
+      if (profile?.email) {
+        await sendMail({
+          to: profile.email,
+          subject: 'Payment Rejected - BrandSync',
+          template: 'payment-rejected',
+          context: {
+            name: profile.name || 'User',
+            taskTitle: link.title || '',
+            taskId: String(link.id),
+            reason: reason || 'REJECTED',
+            date: new Date().toISOString().split('T')[0]
+          },
+          from: 'accounts@brandsync.lk'
+        });
+      }
+
+      return NextResponse.json({ status: 'ok' });
+    }
+  } catch (error) {
+    console.error('BrandSync admin action error', error);
+    return NextResponse.json({ error: error instanceof Error ? error.message : 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/brandsync-links/[id]/bank-transfer/route.ts
+++ b/src/app/api/brandsync-links/[id]/bank-transfer/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+import { supabaseAdmin } from '@/lib/supabase-admin';
+
+export async function POST(request: Request, { params }: { params: { id: string } }) {
+  try {
+    const formData = await request.formData();
+    const file = formData.get('slip');
+
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: 'No file uploaded' }, { status: 400 });
+    }
+
+    const brandsyncId = Number(params.id);
+    if (!brandsyncId) {
+      return NextResponse.json({ error: 'Invalid BrandSync ID' }, { status: 400 });
+    }
+
+    const extension = file.name.split('.').pop() || 'png';
+    const filePath = `${bradsyncSafePrefix()}${Date.now()}-${Math.random().toString(36).slice(2)}.${extension}`;
+
+    const { error: uploadError } = await supabaseAdmin.storage
+      .from('bank-transfer-slips')
+      .upload(filePath, file as any, { contentType: file.type });
+
+    if (uploadError) {
+      console.error('Bank transfer upload error', uploadError);
+      return NextResponse.json({ error: 'Failed to upload slip' }, { status: 500 });
+    }
+
+    const { data, error: insertError } = await supabaseAdmin
+      .from('brandsync_bank_transfer_slips')
+      .insert({ brandsync_id: brandsyncId, slip_path: filePath })
+      .select('id, brandsync_id, slip_path, status, created_at')
+      .single();
+
+    if (insertError) {
+      console.error('Failed to insert brandsync bank transfer slip', insertError);
+      // cleanup
+      await supabaseAdmin.storage.from('bank-transfer-slips').remove([filePath]);
+      return NextResponse.json({ error: 'Failed to save slip' }, { status: 500 });
+    }
+
+    return NextResponse.json({ slip: data }, { status: 201 });
+  } catch (error) {
+    console.error('brandsync bank transfer error', error);
+    return NextResponse.json({ error: error instanceof Error ? error.message : 'Internal server error' }, { status: 500 });
+  }
+}
+
+function bradsyncSafePrefix() {
+  return 'brandsync_slips/';
+}

--- a/src/app/api/brandsync-links/route.ts
+++ b/src/app/api/brandsync-links/route.ts
@@ -1,0 +1,265 @@
+import { NextResponse } from "next/server";
+import crypto from "crypto";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { z } from "zod";
+import { env } from "@/lib/env";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import type { Database } from "@/types/database.types";
+import { buildBrandSyncUrl } from "@/lib/utils/brandsync-link";
+
+const platformSchema = z.enum(["YOUTUBE", "TIKTOK", "FACEBOOK"]);
+
+const requestSchema = z.object({
+  title: z.string().trim().min(1, "Title is required").max(120, "Title is too long"),
+  platform: platformSchema,
+  videoUrl: z.string().trim().url("Enter a valid video URL"),
+  shares: z.preprocess((v) => Number(v), z.number().int().min(0)),
+  paid: z.boolean().optional(),
+});
+
+type BrandSyncLinkRow = Database["public"]["Tables"]["brandsync_links"]["Row"];
+
+function getOrigin(request: Request) {
+  return new URL(request.url).origin;
+}
+
+function getPublicOrigin(request: Request) {
+  return env.APP_URL ?? getOrigin(request);
+}
+
+async function getCurrentUser() {
+  const cookieStore = cookies();
+  const supabase = createRouteHandlerClient<Database>({ cookies: () => cookieStore });
+  const { data: { user }, error } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    return null;
+  }
+
+  return user;
+}
+
+async function uploadThumbnail(file: File, userId: string) {
+  const extension = file.name.split(".").pop() || "png";
+  const filePath = `${userId}/${crypto.randomUUID()}.${extension}`;
+
+  const { error } = await supabaseAdmin.storage
+    .from("proof-images")
+    .upload(filePath, file, {
+      contentType: file.type || "image/png",
+      upsert: false,
+    });
+
+  if (error) {
+    throw error;
+  }
+
+  return filePath;
+}
+
+async function getThumbnailUrl(thumbnailPath: string | null) {
+  if (!thumbnailPath) {
+    return null;
+  }
+
+  const { data, error } = await supabaseAdmin.storage
+    .from("proof-images")
+    .createSignedUrl(thumbnailPath, 60 * 60);
+
+  if (error) {
+    return null;
+  }
+
+  return data.signedUrl;
+}
+
+function mapLink(row: BrandSyncLinkRow, origin: string, thumbnailUrl: string | null) {
+  return {
+    id: row.id,
+    title: row.title,
+    platform: row.platform,
+    shares: row.shares,
+    isPaid: row.is_paid,
+    amount: Number(row.amount || 0),
+    thumbnailUrl,
+    brandSyncUrl: buildBrandSyncUrl(origin, row.token),
+    createdAt: row.created_at,
+  };
+}
+
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url);
+    const scope = url.searchParams.get("scope");
+
+    if (scope === "public") {
+      const origin = getPublicOrigin(request);
+      const { data, error } = await supabaseAdmin
+        .from("brandsync_links")
+        .select("id, title, platform, token, thumbnail_path, created_at")
+        .eq('is_paid', true)
+        .order("created_at", { ascending: false })
+        .limit(50);
+
+      if (error) {
+        console.error("BrandSync public load error:", error);
+        return NextResponse.json(
+          {
+            error: error.message || "Failed to load BrandSync links",
+            details: error.details ?? null,
+            hint: error.hint ?? null,
+            code: error.code ?? null,
+          },
+          { status: 500 }
+        );
+      }
+
+      const links = await Promise.all(
+        (data ?? []).map(async (row) => {
+          const thumbnailUrl = await getThumbnailUrl(row.thumbnail_path);
+          return mapLink(row as BrandSyncLinkRow, origin, thumbnailUrl);
+        })
+      );
+
+      return NextResponse.json({ links });
+    }
+
+    const user = await getCurrentUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const origin = getPublicOrigin(request);
+    const { data, error } = await supabaseAdmin
+      .from("brandsync_links")
+      .select("id, title, platform, token, thumbnail_path, created_at")
+      .eq("user_id", user.id)
+      .order("created_at", { ascending: false })
+      .limit(12);
+
+    if (error) {
+      console.error("BrandSync user load error:", error);
+      return NextResponse.json(
+        {
+          error: error.message || "Failed to load BrandSync links",
+          details: error.details ?? null,
+          hint: error.hint ?? null,
+          code: error.code ?? null,
+        },
+        { status: 500 }
+      );
+    }
+
+    const links = await Promise.all(
+      (data ?? []).map(async (row) => {
+        const thumbnailUrl = await getThumbnailUrl(row.thumbnail_path);
+        return mapLink(row as BrandSyncLinkRow, origin, thumbnailUrl);
+      })
+    );
+
+    return NextResponse.json({ links });
+  } catch (error) {
+    console.error("BrandSync link list error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const user = await getCurrentUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const formData = await request.formData();
+    const parsed = requestSchema.parse({
+      title: formData.get("title"),
+      platform: formData.get("platform"),
+      videoUrl: formData.get("videoUrl"),
+      shares: formData.get("shares") ?? 0,
+      paid: formData.get("paid") === "true",
+    });
+
+    const thumbnailValue = formData.get("thumbnail");
+    const thumbnailFile = thumbnailValue instanceof File && thumbnailValue.size > 0 ? thumbnailValue : null;
+
+    if (thumbnailFile && thumbnailFile.size > 5 * 1024 * 1024) {
+      return NextResponse.json({ error: "Thumbnail must be smaller than 5MB" }, { status: 400 });
+    }
+
+    let thumbnailPath: string | null = null;
+
+    if (thumbnailFile) {
+      thumbnailPath = await uploadThumbnail(thumbnailFile, user.id);
+    }
+
+    // Enforce shares business rule: minimum 100 shares, Rs.6 per share
+    const shares = parsed.shares ?? 0;
+    const MIN_SHARES = 100;
+    const PRICE_PER_SHARE = 6; // LKR
+
+    if (shares < MIN_SHARES) {
+      return NextResponse.json({ error: `Minimum shares is ${MIN_SHARES}` }, { status: 400 });
+    }
+
+    const amount = shares * PRICE_PER_SHARE;
+
+    if (shares > MIN_SHARES && !parsed.paid) {
+      // Require payment before creating the link
+      return NextResponse.json({ error: "Payment required", requiredAmount: amount }, { status: 402 });
+    }
+
+    const token = crypto.randomUUID().replace(/-/g, "");
+    const origin = getPublicOrigin(request);
+
+    const { data: createdLink, error: insertError } = await supabaseAdmin
+      .from("brandsync_links")
+      .insert({
+        token,
+        user_id: user.id,
+        title: parsed.title,
+        platform: parsed.platform,
+        platform_url: parsed.videoUrl,
+        thumbnail_path: thumbnailPath,
+        shares: shares,
+        is_paid: Boolean(parsed.paid),
+        amount: amount,
+      })
+      .select("id, title, platform, token, thumbnail_path, created_at, shares, is_paid, amount")
+      .single();
+
+    if (insertError || !createdLink) {
+      if (thumbnailPath) {
+        await supabaseAdmin.storage.from("proof-images").remove([thumbnailPath]);
+      }
+
+      console.error("BrandSync insert error:", insertError);
+      return NextResponse.json(
+        {
+          error: insertError?.message || "Failed to create BrandSync link",
+          details: insertError?.details ?? null,
+          hint: insertError?.hint ?? null,
+          code: insertError?.code ?? null,
+        },
+        { status: 500 }
+      );
+    }
+
+    const thumbnailUrl = await getThumbnailUrl(createdLink.thumbnail_path);
+
+    return NextResponse.json({
+      link: mapLink(createdLink as BrandSyncLinkRow, origin, thumbnailUrl),
+    }, { status: 201 });
+  } catch (error) {
+    console.error("BrandSync link create error:", error);
+
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: "Invalid request data", details: error.issues }, { status: 400 });
+    }
+
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/payment/initialize/brandsync/[id]/route.ts
+++ b/src/app/api/payment/initialize/brandsync/[id]/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
+import { Database } from "@/types/database.types";
+import { getPaymentEnvironmentVariables, generatePayHereHash } from "@/lib/utils/payment";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const id = Number(params.id);
+    if (!id) return NextResponse.json({ error: 'Invalid BrandSync id' }, { status: 400 });
+
+    const { data: row, error } = await supabaseAdmin
+      .from('brandsync_links')
+      .select('id, title, platform, amount, user_id')
+      .eq('id', id)
+      .single();
+
+    if (error || !row) return NextResponse.json({ error: 'BrandSync not found' }, { status: 404 });
+
+    if (row.is_paid) return NextResponse.json({ error: 'Already paid' }, { status: 400 });
+
+    const { merchantId, merchantSecret, notifyUrl, returnUrl, cancelUrl, checkoutUrl, authorizeUrl } = await getPaymentEnvironmentVariables();
+
+    const formattedAmount = Number(row.amount || 0).toFixed(2);
+    const orderId = `BRANDSYNC:${id}`;
+    const hash = generatePayHereHash(merchantId, orderId, formattedAmount, 'LKR', merchantSecret);
+
+    const userRes = await createServerComponentClient<Database>({ cookies }).auth.getUser();
+    const user = userRes.data.user;
+    const firstName = user?.user_metadata?.full_name?.split(' ')[0] || 'Buyer';
+    const lastName = user?.user_metadata?.full_name?.split(' ').slice(1).join(' ') || firstName;
+
+    const formData = {
+      merchant_id: merchantId,
+      return_url: returnUrl,
+      cancel_url: cancelUrl,
+      notify_url: notifyUrl,
+      order_id: orderId,
+      items: row.title || 'BrandSync Link',
+      currency: 'LKR',
+      amount: formattedAmount,
+      first_name: firstName,
+      last_name: lastName,
+      email: user?.email || '',
+      phone: '',
+      address: 'Sri Lanka',
+      city: 'Colombo',
+      country: 'Sri Lanka',
+      hash,
+      custom_1: user?.id,
+      custom_2: String(id),
+      checkout_url: checkoutUrl,
+      authorize_url: authorizeUrl
+    };
+
+    return NextResponse.json(formData);
+  } catch (error) {
+    console.error('Init existing BrandSync payment error', error);
+    return NextResponse.json({ error: error instanceof Error ? error.message : 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/payment/initialize/brandsync/route.ts
+++ b/src/app/api/payment/initialize/brandsync/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
+import { Database } from "@/types/database.types";
+import { generatePayHereHash, getPaymentEnvironmentVariables } from "@/lib/utils/payment";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+
+    const shares = Number(body.shares || 0);
+    const title = String(body.title || 'BrandSync Link');
+    const platform = String(body.platform || 'YOUTUBE');
+    const videoUrl = String(body.videoUrl || '');
+    const createOnly = Boolean(body.createOnly);
+
+    if (!shares || shares < 100) {
+      return NextResponse.json({ error: 'Minimum shares is 100' }, { status: 400 });
+    }
+
+    const amount = shares * 6; // LKR
+
+    // Create pending BrandSync row
+    const { data: created, error: insertError } = await supabaseAdmin
+      .from('brandsync_links')
+      .insert({
+        token: crypto.randomUUID().replace(/-/g, ''),
+        user_id: (await createServerComponentClient<Database>({ cookies }).auth.getUser()).data.user?.id,
+        title,
+        platform,
+        platform_url: videoUrl,
+        shares,
+        is_paid: false,
+        amount
+      })
+      .select('id')
+      .single();
+
+    if (insertError || !created) {
+      console.error('Failed to create brandsync pending row', insertError);
+      return NextResponse.json({ error: 'Failed to initialize payment' }, { status: 500 });
+    }
+
+    const brandsyncId = created.id;
+    // If only creating the pending row (for bank transfer flow), return id and amount
+    if (createOnly) {
+      return NextResponse.json({ brandsyncId, amount }, { status: 201 });
+    }
+
+    const { merchantId, merchantSecret, notifyUrl, returnUrl, cancelUrl, checkoutUrl, authorizeUrl } = await getPaymentEnvironmentVariables();
+
+    const formattedAmount = Number(amount).toFixed(2);
+    const hash = generatePayHereHash(merchantId, `BRANDSYNC:${brandsyncId}`, formattedAmount, 'LKR', merchantSecret);
+
+    const userRes = await createServerComponentClient<Database>({ cookies }).auth.getUser();
+    const user = userRes.data.user;
+    const firstName = user?.user_metadata?.full_name?.split(' ')[0] || 'Buyer';
+    const lastName = user?.user_metadata?.full_name?.split(' ').slice(1).join(' ') || firstName;
+
+    const formData = {
+      merchant_id: merchantId,
+      return_url: returnUrl,
+      cancel_url: cancelUrl,
+      notify_url: notifyUrl,
+      order_id: `BRANDSYNC:${brandsyncId}`,
+      items: title,
+      currency: 'LKR',
+      amount: formattedAmount,
+      first_name: firstName,
+      last_name: lastName,
+      email: user?.email || '',
+      phone: '',
+      address: 'Sri Lanka',
+      city: 'Colombo',
+      country: 'Sri Lanka',
+      hash,
+      custom_1: user?.id,
+      custom_2: brandsyncId.toString(),
+      checkout_url: checkoutUrl,
+      authorize_url: authorizeUrl
+    };
+
+    return NextResponse.json(formData);
+  } catch (error) {
+    console.error('BrandSync payment initialize error', error);
+    return NextResponse.json({ error: error instanceof Error ? error.message : 'Internal server error' }, { status: 500 });
+  }
+}
+
+import crypto from 'crypto';

--- a/src/app/api/payment/notify/route.ts
+++ b/src/app/api/payment/notify/route.ts
@@ -51,7 +51,8 @@ async function validateFormData(formData: FormData): Promise<PayhereNotification
   }
 
   // Validate order_id format (must be a number)
-  if (!/^\d+$/.test(notification.order_id!)) {
+  // Validate order_id format (must be a number or BRANDSYNC:<id>)
+  if (!/^\d+$/.test(notification.order_id!) && !/^BRANDSYNC:\d+$/.test(notification.order_id!)) {
     throw new Error('Invalid order_id format');
   }
 
@@ -165,28 +166,42 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const taskId = parseInt(notification.order_id);
+    // Determine if this is a task payment or a BrandSync payment
+    if (notification.order_id!.startsWith('BRANDSYNC:')) {
+      const bsId = parseInt(notification.order_id!.split(':')[1]);
+      if (notification.status_code === '2') {
+        // Mark BrandSync link as paid
+        const { error } = await supabaseAdmin
+          .from('brandsync_links')
+          .update({ is_paid: true })
+          .eq('id', bsId);
 
-    // Handle successful payment
-    if (notification.status_code === '2') {
-      // Verify task exists and is in DRAFT status
-      await verifyTaskStatus(taskId);
+        if (error) throw error;
+      }
+    } else {
+      const taskId = parseInt(notification.order_id);
 
-      // Update payment status and task status
-      const paymentDetails = {
-        is_paid: true,
-        payment_method: 'PAYMENT_GATEWAY' as const,
-        paid_at: new Date().toISOString(),
-        metadata: {
-          payment_id: notification.payment_id,
-          payment_method: notification.method,
-          card_holder_name: notification.card_holder_name,
-          card_no: notification.card_no,
-          card_expiry: notification.card_expiry
-        }
-      };
+      // Handle successful payment for task
+      if (notification.status_code === '2') {
+        // Verify task exists and is in DRAFT status
+        await verifyTaskStatus(taskId);
 
-      await updatePaymentStatus(taskId, paymentDetails);
+        // Update payment status and task status
+        const paymentDetails = {
+          is_paid: true,
+          payment_method: 'PAYMENT_GATEWAY' as const,
+          paid_at: new Date().toISOString(),
+          metadata: {
+            payment_id: notification.payment_id,
+            payment_method: notification.method,
+            card_holder_name: notification.card_holder_name,
+            card_no: notification.card_no,
+            card_expiry: notification.card_expiry
+          }
+        };
+
+        await updatePaymentStatus(taskId, paymentDetails);
+      }
     }
 
     return NextResponse.json({ status: 'ok' });

--- a/src/app/brandsync/error/page.tsx
+++ b/src/app/brandsync/error/page.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import Link from "next/link";
+
+export default function BrandSyncErrorPage({ searchParams }: { searchParams?: { code?: string } }) {
+  const code = searchParams?.code || '';
+
+  let title = 'Link unavailable';
+  let message = 'This BrandSync link is not available.';
+
+  if (code === 'already_clicked') {
+    title = 'Already opened';
+    message = 'You have already opened this link. Each BrandSync link can only be opened once from the same IP address.';
+  } else if (code === 'not_available') {
+    title = 'Link not active';
+    message = 'This BrandSync link is not active yet. It will become available after payment is confirmed.';
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-white dark:bg-gray-900">
+      <div className="max-w-md w-full p-8 rounded-lg border bg-gray-50 dark:bg-gray-800">
+        <h1 className="text-2xl font-semibold mb-2 text-gray-900 dark:text-gray-100">{title}</h1>
+        <p className="text-sm text-muted-foreground mb-6">{message}</p>
+
+        <div className="flex gap-3">
+          <Link href="/" className="inline-flex items-center justify-center px-4 py-2 bg-pink-600 text-white rounded-md">Home</Link>
+          <Link href="/dashboard" className="inline-flex items-center justify-center px-4 py-2 border rounded-md">Dashboard</Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/admin/payments/page.tsx
+++ b/src/app/dashboard/admin/payments/page.tsx
@@ -139,6 +139,31 @@ export default function AdminPaymentsPage() {
         status: statuses?.find(status => status.transfer_id === slip.id)
       })) as PaymentWithDetails[];
 
+      // Fetch BrandSync bank transfer slips
+      const { data: bsSlips, error: bsError } = await supabase
+        .from('brandsync_bank_transfer_slips')
+        .select(`*, brandsync:brandsync_links(id, title, amount, user_id)`)
+        .order('created_at', { ascending: false });
+
+      if (bsError) throw bsError;
+
+      const brandSyncPayments = (bsSlips || []).map((s: any) => ({
+        id: s.id,
+        slip: s.slip_path,
+        created_at: s.created_at,
+        slipUrl: null,
+        status: { status: s.status, reviewed_at: null, reviewed_by: null },
+        task: {
+          title: s.brandsync?.title || 'BrandSync',
+          description: null,
+        },
+        brandsync: s.brandsync || null,
+        isBrandSync: true,
+      })) as any[];
+
+      // Combine both types
+      combinedData = combinedData.concat(brandSyncPayments) as PaymentWithDetails[];
+
       if (statusFilter !== "ALL") {
         combinedData = combinedData.filter(
           payment => payment.status?.status === statusFilter
@@ -151,8 +176,10 @@ export default function AdminPaymentsPage() {
 
       const paymentsWithDetails = await Promise.all(
         paginatedData.map(async (payment) => {
-          const userId = payment.task?.user_id;
+          const userId = payment.task?.user_id || (payment as any).brandsync?.user_id;
           if (!userId) return payment;
+
+          const slipPath = (payment as any).slip || payment.slip;
 
           const [buyerProfile, buyerTasks, slipUrl] = await Promise.all([
             supabase
@@ -170,7 +197,7 @@ export default function AdminPaymentsPage() {
                 )
               `)
               .eq('user_id', userId),
-            getStorageUrl('bank-transfer-slips', payment.slip)
+            getStorageUrl('bank-transfer-slips', slipPath)
           ]);
 
           const totalPaid = buyerTasks.data?.reduce((sum, task) => {
@@ -234,60 +261,74 @@ export default function AdminPaymentsPage() {
     customReason?: string
   ) => {
     const payment = confirmationModal.payment;
-    if (!payment || !payment.task?.cost) return;
-
+    if (!payment) return;
+    const isBrand = (payment as any).isBrandSync === true;
+    if (!isBrand && !payment.task?.cost) return;
     try {
       setProcessingPayment(payment.id);
 
-      const { error } = await supabase.rpc('update_bank_transfer_payment', {
-        transfer_id_param: payment.id,
-        task_cost_id_param: payment.task.cost.id,
-        is_accepted_param: isAccepted
-      });
-
-      if (error) throw error;
-
-      // Send email notification
-      const emailContext: Record<string, string> = {
-        name: payment.buyer?.name || 'User',
-        taskTitle: payment.task.title || '',
-        taskId: payment.task.task_id?.toString() || '',
-        amount: payment.task.cost.amount.toString(),
-        date: format(new Date(), 'MMMM d, yyyy'),
-      };
-
-      if (isAccepted) {
-        await sendMail({
-          to: payment.buyer?.email || '',
-          subject: 'Payment Accepted - BrandSync',
-          template: 'payment-accepted',
-          context: emailContext,
-          from: 'accounts@brandsync.lk'
+      if ((payment as any).isBrandSync) {
+        // Call admin endpoint for BrandSync slips
+        const resp = await fetch(`/api/admin/brandsync-payments/${payment.id}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: isAccepted ? 'accept' : 'reject', reason: customReason || undefined })
         });
-      } else if (rejectionReason) {
-        const rejectionLabel = rejectionReasonsList.find(
-          (r) => r.value === rejectionReason
-        )?.label || 'Payment Rejected';
 
-        await sendMail({
-          to: payment.buyer?.email || '',
-          subject: 'Payment Rejected - BrandSync',
-          template: 'payment-rejected',
-          context: {
-            ...emailContext,
-            reason: rejectionLabel,
-            actionRequired: getActionRequired(
-              rejectionReason,
-              customReason || '',
-              payment.task.cost.amount.toString()
-            )
-          },
-          from: 'accounts@brandsync.lk'
+        if (!resp.ok) throw new Error('Failed to update BrandSync payment');
+
+        toast.success(`Payment ${isAccepted ? 'accepted' : 'rejected'} successfully`);
+      } else {
+        const { error } = await supabase.rpc('update_bank_transfer_payment', {
+          transfer_id_param: payment.id,
+          task_cost_id_param: payment.task.cost.id,
+          is_accepted_param: isAccepted
         });
+
+        if (error) throw error;
+
+        // Send email notification
+        const emailContext: Record<string, string> = {
+          name: payment.buyer?.name || 'User',
+          taskTitle: payment.task.title || '',
+          taskId: payment.task.task_id?.toString() || '',
+          amount: payment.task.cost.amount.toString(),
+          date: format(new Date(), 'MMMM d, yyyy'),
+        };
+
+        if (isAccepted) {
+          await sendMail({
+            to: payment.buyer?.email || '',
+            subject: 'Payment Accepted - BrandSync',
+            template: 'payment-accepted',
+            context: emailContext,
+            from: 'accounts@brandsync.lk'
+          });
+        } else if (rejectionReason) {
+          const rejectionLabel = rejectionReasonsList.find(
+            (r) => r.value === rejectionReason
+          )?.label || 'Payment Rejected';
+
+          await sendMail({
+            to: payment.buyer?.email || '',
+            subject: 'Payment Rejected - BrandSync',
+            template: 'payment-rejected',
+            context: {
+              ...emailContext,
+              reason: rejectionLabel,
+              actionRequired: getActionRequired(
+                rejectionReason,
+                customReason || '',
+                payment.task.cost.amount.toString()
+              )
+            },
+            from: 'accounts@brandsync.lk'
+          });
+        }
+
+        toast.success(`Payment ${isAccepted ? 'accepted' : 'rejected'} successfully`);
       }
 
-      toast.success(`Payment ${isAccepted ? 'accepted' : 'rejected'} successfully`);
-      
       router.refresh();
       await fetchPayments();
     } catch (error) {
@@ -492,8 +533,8 @@ export default function AdminPaymentsPage() {
           onConfirm={handlePaymentUpdate}
           action={confirmationModal.action}
           paymentDetails={{
-            taskTitle: confirmationModal.payment.task?.title || '',
-            amount: confirmationModal.payment.task?.cost?.amount || 0,
+            taskTitle: (confirmationModal.payment as any).isBrandSync ? ((confirmationModal.payment as any).brandsync?.title || '') : (confirmationModal.payment.task?.title || ''),
+            amount: (confirmationModal.payment as any).isBrandSync ? ((confirmationModal.payment as any).brandsync?.amount || 0) : (confirmationModal.payment.task?.cost?.amount || 0),
           }}
         />
       )}

--- a/src/app/dashboard/buyer/page.tsx
+++ b/src/app/dashboard/buyer/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { toast } from 'sonner';
 import { signOut } from "@/lib/supabase";
 import { TaskCard } from "@/components/dashboard/task-card";
 import { Database } from "@/types/database.types";
@@ -24,6 +25,7 @@ import {
 } from "@/components/ui/select";
 import { Search, SlidersHorizontal } from "lucide-react";
 import { SearchInput } from "@/components/ui/search-input";
+import { BrandSyncLinkModal } from "@/components/dashboard/brandsync-link-modal";
 
 const ITEMS_PER_PAGE = 6;
 
@@ -78,6 +80,10 @@ export default function BuyerDashboardPage() {
   const [filteredTasks, setFilteredTasks] = useState<TaskDetail[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [showPlatformModal, setShowPlatformModal] = useState(false);
+  const [showBrandSyncModal, setShowBrandSyncModal] = useState(false);
+  const [brandSyncLinks, setBrandSyncLinks] = useState<Array<{ id: number; title: string; platform: string; brandSyncUrl: string; thumbnailUrl?: string | null; shares?: number; isPaid?: boolean; amount?: number;}>>([]);
+  const [isLoadingLinks, setIsLoadingLinks] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState<Record<number, number>>({});
   const [searchQuery, setSearchQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState<string>("ALL");
   const [platformFilter, setPlatformFilter] = useState<string>("ALL");
@@ -107,6 +113,22 @@ export default function BuyerDashboardPage() {
     };
 
     fetchTasks();
+    // load user's BrandSync links (non-blocking)
+    const loadLinks = async () => {
+      setIsLoadingLinks(true);
+      try {
+        const res = await fetch('/api/brandsync-links', { credentials: 'include' });
+        if (!res.ok) return;
+        const data = await res.json();
+        setBrandSyncLinks(data.links ?? []);
+      } catch (err) {
+        console.error('Failed to load BrandSync links', err);
+      } finally {
+        setIsLoadingLinks(false);
+      }
+    };
+
+    loadLinks();
   }, [supabase, router]);
 
   useEffect(() => {
@@ -233,6 +255,71 @@ export default function BuyerDashboardPage() {
     </div>
   );
 
+  const handleUploadSlipForLink = async (e: React.ChangeEvent<HTMLInputElement>, linkId: number) => {
+    try {
+      const file = e.target?.files?.[0];
+      if (!file) {
+        toast.error('No file selected');
+        return;
+      }
+
+      const fd = new FormData();
+      fd.append('slip', file);
+
+
+      setUploadProgress(prev => ({ ...prev, [linkId]: 0 }));
+
+      await new Promise<void>((resolve, reject) => {
+        const xhr = new XMLHttpRequest();
+        xhr.open('POST', `/api/brandsync-links/${linkId}/bank-transfer`);
+
+        xhr.upload.onprogress = (ev) => {
+          if (ev.lengthComputable) {
+            const percent = Math.round((ev.loaded / ev.total) * 100);
+            setUploadProgress(prev => ({ ...prev, [linkId]: percent }));
+          }
+        };
+
+        xhr.onload = () => {
+          try {
+            if (xhr.status >= 200 && xhr.status < 300) {
+              resolve();
+            } else {
+              const text = xhr.responseText || `Upload failed: ${xhr.status}`;
+              let parsed: any = null;
+              try { parsed = JSON.parse(text); } catch {}
+              const msg = parsed?.error || parsed?.message || text;
+              reject(new Error(String(msg)));
+            }
+          } catch (e) {
+            reject(e instanceof Error ? e : new Error('Unknown upload error'));
+          }
+        };
+
+        xhr.onerror = () => reject(new Error('Upload network error'));
+
+        xhr.send(fd);
+      });
+
+      toast.success('Slip uploaded — admin will verify');
+      // refresh links
+      const updated = await fetch('/api/brandsync-links', { credentials: 'include' });
+      if (updated.ok) {
+        const json = await updated.json();
+        setBrandSyncLinks(json.links ?? []);
+      }
+    } catch (err) {
+      console.error(err);
+      toast.error('Failed to upload slip');
+    } finally {
+      setUploadProgress(prev => {
+        const copy = { ...prev };
+        delete copy[linkId];
+        return copy;
+      });
+    }
+  };
+
   if (isLoading) {
     return (
       <div className="min-h-screen w-full bg-white dark:bg-gray-950">
@@ -279,6 +366,13 @@ export default function BuyerDashboardPage() {
             >
               Create New Task
             </Button>
+            <Button
+              variant="outline"
+              onClick={() => setShowBrandSyncModal(true)}
+              className="w-full sm:w-auto border-pink-200 text-pink-700 hover:bg-pink-50 dark:border-pink-800 dark:text-pink-300 dark:hover:bg-pink-950/40"
+            >
+              Add BrandSync Link
+            </Button>
             <Button 
               variant="outline" 
               onClick={handleLogout}
@@ -289,6 +383,11 @@ export default function BuyerDashboardPage() {
             </Button>
           </div>
         </motion.div>
+
+        <BrandSyncLinkModal
+          open={showBrandSyncModal}
+          onOpenChange={setShowBrandSyncModal}
+        />
         
         <motion.div 
           initial={{ opacity: 0, y: 20 }}
@@ -408,6 +507,111 @@ export default function BuyerDashboardPage() {
             </DialogContent>
           </Dialog>
 
+        </motion.div>
+
+        {/* BrandSync Links Section */}
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="mb-8"
+        >
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">BrandSync Links</h2>
+            <div className="flex items-center gap-2">
+              <Button onClick={() => setShowBrandSyncModal(true)} className="bg-pink-600 hover:bg-pink-700 text-white">
+                Create Link
+              </Button>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {brandSyncLinks.length === 0 ? (
+                <div className="col-span-full rounded-lg border border-dashed p-6 text-center">
+                  <p className="text-lg font-medium">No BrandSync links yet</p>
+                  <p className="text-sm text-muted-foreground mt-2">Create a link to share your external video while hiding the original URL.</p>
+                  <div className="mt-4">
+                    <Button onClick={() => setShowBrandSyncModal(true)} className="bg-pink-600 hover:bg-pink-700 text-white">Create your first link</Button>
+                  </div>
+                </div>
+              ) : (
+                brandSyncLinks.map(link => (
+                  <Card key={link.id} className="overflow-hidden">
+                    <CardHeader>
+                      <CardTitle>
+                        <div className="flex items-center justify-between w-full">
+                          <span className="truncate max-w-[60%]">{link.title}</span>
+                          <div className="flex items-center gap-2">
+                            <span className="text-xs text-muted-foreground">{link.platform}</span>
+                          </div>
+                        </div>
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="flex items-center gap-3">
+                        {link.thumbnailUrl ? (
+                          <img src={link.thumbnailUrl} alt={link.title} className="h-16 w-24 rounded-md object-cover" />
+                        ) : (
+                          <div className="h-16 w-24 rounded-md bg-muted" />
+                        )}
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm truncate">{link.title}</p>
+                          <p className="text-xs text-muted-foreground mt-1">Shares: {link.shares ?? 0} • Amount: LKR {Number(link.amount ?? 0).toLocaleString()}</p>
+                          {!link.isPaid && (
+                            <p className="text-xs text-yellow-700 mt-1">Status: Awaiting payment</p>
+                          )}
+                        </div>
+                      </div>
+                      <div className="flex gap-2 mt-4">
+                        {link.isPaid ? (
+                          <Button asChild variant="outline">
+                            <a href={link.brandSyncUrl} target="_blank" rel="noreferrer">Open</a>
+                          </Button>
+                        ) : (
+                          <>
+                            <Button type="button" onClick={async () => {
+                              // initialize PayHere for existing brandsync
+                              try {
+                                const resp = await fetch(`/api/payment/initialize/brandsync/${link.id}`, { method: 'POST' });
+                                if (!resp.ok) { const e = await resp.json().catch(()=>({})); throw new Error(e?.error||'Failed to init payment'); }
+                                const formData = await resp.json();
+                                const paymentForm = document.createElement('form');
+                                paymentForm.method = 'post';
+                                paymentForm.action = formData.checkout_url;
+                                paymentForm.target = '_blank';
+                                Object.entries(formData).forEach(([key, value]) => {
+                                  if (value !== undefined && value !== null) {
+                                    const input = document.createElement('input');
+                                    input.type = 'hidden';
+                                    input.name = key;
+                                    input.value = String(value);
+                                    paymentForm.appendChild(input);
+                                  }
+                                });
+                                document.body.appendChild(paymentForm);
+                                paymentForm.submit();
+                                setTimeout(()=>document.body.removeChild(paymentForm),100);
+                              } catch (err) { console.error(err); toast.error('Failed to initialize payment'); }
+                            }} className="bg-green-600 text-white">Pay</Button>
+                            <label className="inline-flex items-center px-3 py-2 border rounded-md cursor-pointer">
+                                  <input type="file" accept="image/*,application/pdf" className="hidden" onChange={(e)=>handleUploadSlipForLink(e, link.id)} />
+                                  Upload Slip
+                                </label>
+                                {uploadProgress[link.id] != null && (
+                                  <div className="w-full mt-2">
+                                    <div className="h-2 bg-gray-200 rounded overflow-hidden">
+                                      <div className="h-2 bg-pink-600" style={{ width: `${uploadProgress[link.id]}%` }} />
+                                    </div>
+                                    <p className="text-xs text-muted-foreground">Uploading: {uploadProgress[link.id]}%</p>
+                                  </div>
+                                )}
+                          </>
+                        )}
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))
+              )}
+          </div>
         </motion.div>
 
         <motion.div

--- a/src/app/dashboard/influencer/page.tsx
+++ b/src/app/dashboard/influencer/page.tsx
@@ -22,7 +22,8 @@ import {
 import { ChevronsLeft, ChevronsRight, ChevronLeft, ChevronRight } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
-import { AlertCircle } from "lucide-react";
+import { AlertCircle, Copy, ExternalLink } from "lucide-react";
+import { toast } from "sonner";
 
 const ITEMS_PER_PAGE = 6;
 
@@ -126,6 +127,15 @@ type ConnectedPlatform = {
   url: string;
 };
 
+type BrandSyncLinkEntry = {
+  id: number;
+  title: string;
+  platform: Database['public']['Enums']['Platforms'];
+  thumbnailUrl?: string | null;
+  brandSyncUrl: string;
+  createdAt: string;
+};
+
 export default function InfluencerDashboardPage() {
   const router = useRouter();
   const supabase = createClientComponentClient<Database>();
@@ -157,6 +167,8 @@ export default function InfluencerDashboardPage() {
   const [currentPage, setCurrentPage] = useState(1);
   const [filteredTasks, setFilteredTasks] = useState<(TaskDetail & { application?: TaskApplication })[]>([]);
   const [hasIncompleteTask, setHasIncompleteTask] = useState(false);
+  const [brandSyncLinks, setBrandSyncLinks] = useState<BrandSyncLinkEntry[]>([]);
+  const [isLoadingBrandSyncLinks, setIsLoadingBrandSyncLinks] = useState(true);
   // Static FX rate from env: 1 USD = NEXT_PUBLIC_LKR_PER_USD LKR
   const LKR_PER_USD = Number(process.env.NEXT_PUBLIC_LKR_PER_USD ?? "295");
   const LKR_TO_USD = 1 / (LKR_PER_USD || 295);
@@ -239,6 +251,20 @@ export default function InfluencerDashboardPage() {
             .eq("status", "ACTIVE")
         ]);
 
+        try {
+          const response = await fetch("/api/brandsync-links?scope=public");
+          const data = await response.json();
+
+          if (!response.ok) {
+            throw new Error(data.error || "Failed to load BrandSync links");
+          }
+
+          setBrandSyncLinks(data.links || []);
+        } catch (brandSyncError) {
+          console.error("Error fetching BrandSync links:", brandSyncError);
+          setBrandSyncLinks([]);
+        }
+
         setAccountBalance(balanceResponse.data);
 
         // Combine verified and pending profiles
@@ -293,6 +319,7 @@ export default function InfluencerDashboardPage() {
       } catch (error) {
         console.error('Error fetching data:', error);
       } finally {
+        setIsLoadingBrandSyncLinks(false);
         setIsLoading(false);
       }
     };
@@ -553,6 +580,94 @@ export default function InfluencerDashboardPage() {
               <p className="text-sm text-indigo-600/80 dark:text-indigo-300/80 mt-1">Active platforms</p>
             </CardContent>
           </Card>
+        </motion.div>
+
+        {/* BrandSync Links */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.15 }}
+          className="mb-12"
+        >
+          <div className="flex items-center justify-between mb-6">
+            <div>
+              <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">BrandSync Links</h2>
+              <p className="text-muted-foreground mt-1">Latest buyer-created links you can open directly</p>
+            </div>
+          </div>
+
+          {isLoadingBrandSyncLinks ? (
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {[...Array(3)].map((_, index) => (
+                <Card key={index} className="border border-gray-200 dark:border-gray-800 overflow-hidden">
+                  <CardContent className="p-4">
+                    <div className="h-40 rounded-lg bg-gray-100 dark:bg-gray-800 animate-pulse" />
+                    <div className="mt-4 h-4 w-3/4 rounded bg-gray-100 dark:bg-gray-800 animate-pulse" />
+                    <div className="mt-2 h-3 w-1/2 rounded bg-gray-100 dark:bg-gray-800 animate-pulse" />
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          ) : brandSyncLinks.length > 0 ? (
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {brandSyncLinks.map((link) => (
+                <motion.div
+                  key={link.id}
+                  whileHover={{ scale: 1.01 }}
+                  transition={{ duration: 0.2 }}
+                >
+                  <Card className="h-full overflow-hidden border border-pink-100 dark:border-pink-900/20 bg-white dark:bg-gray-900 hover:shadow-lg transition-shadow">
+                    {link.thumbnailUrl ? (
+                      <img
+                        src={link.thumbnailUrl}
+                        alt={link.title}
+                        className="h-44 w-full object-cover"
+                      />
+                    ) : (
+                      <div className="h-44 w-full bg-gradient-to-br from-pink-100 to-pink-50 dark:from-pink-950/40 dark:to-gray-900" />
+                    )}
+                    <CardContent className="p-4 space-y-3">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <h3 className="font-semibold text-gray-900 dark:text-gray-100 truncate">{link.title}</h3>
+                          <p className="text-sm text-muted-foreground">{link.platform}</p>
+                        </div>
+                        <Badge variant="secondary" className="shrink-0">
+                          {link.platform}
+                        </Badge>
+                      </div>
+
+                      <div className="flex items-center gap-2">
+                        <Button type="button" asChild className="flex-1 bg-pink-600 hover:bg-pink-700 text-white">
+                          <a href={link.brandSyncUrl} target="_blank" rel="noopener noreferrer">
+                            <ExternalLink className="mr-2 h-4 w-4" />
+                            Open Link
+                          </a>
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          onClick={async () => {
+                            await navigator.clipboard.writeText(link.brandSyncUrl);
+                            toast.success("BrandSync link copied");
+                          }}
+                        >
+                          <Copy className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </CardContent>
+                  </Card>
+                </motion.div>
+              ))}
+            </div>
+          ) : (
+            <Card className="border border-dashed border-pink-200 dark:border-pink-900/30 bg-pink-50/40 dark:bg-pink-950/10">
+              <CardContent className="py-10 text-center">
+                <p className="font-medium text-gray-900 dark:text-gray-100">No BrandSync links yet</p>
+                <p className="text-sm text-muted-foreground mt-1">Buyers will see new links here once they create them.</p>
+              </CardContent>
+            </Card>
+          )}
         </motion.div>
 
         {/* Connected Social Media Accounts */}

--- a/src/app/go/[token]/page.tsx
+++ b/src/app/go/[token]/page.tsx
@@ -1,0 +1,63 @@
+import { redirect } from "next/navigation";
+import { decodeBrandSyncToken } from "@/lib/utils/brandsync-link";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { headers } from 'next/headers';
+
+export const dynamic = "force-dynamic";
+
+export default async function BrandSyncRedirectPage({ params }: { params: { token: string } }) {
+  // try to resolve a stored BrandSync link first (only paid links should be public)
+  const { data } = await supabaseAdmin
+    .from("brandsync_links")
+    .select("id, platform_url, is_paid")
+    .eq("token", params.token)
+    .maybeSingle();
+
+  const hdrs: any = headers();
+  const forwarded = (typeof hdrs.get === 'function' ? hdrs.get('x-forwarded-for') : hdrs['x-forwarded-for']) || (typeof hdrs.get === 'function' ? hdrs.get('x-real-ip') : hdrs['x-real-ip']) || '';
+  const ip = String(forwarded).split(',')[0]?.trim() || 'unknown';
+
+  if (data && data.platform_url && /^https?:\/\//i.test(data.platform_url)) {
+    // If the link is stored, ensure it's paid
+    if (!data.is_paid) {
+      redirect('/brandsync/error?code=not_available');
+      return;
+    }
+
+    // Check if this IP already clicked this link
+    try {
+      const { data: existing } = await (supabaseAdmin as any)
+        .from('brandsync_clicks')
+        .select('id')
+        .eq('brandsync_id', data.id)
+        .eq('ip_address', ip)
+        .maybeSingle();
+
+      if (existing) {
+        redirect('/brandsync/error?code=already_clicked');
+        return;
+      }
+
+      // record click
+      await (supabaseAdmin as any).from('brandsync_clicks').insert({ brandsync_id: data.id, ip_address: ip });
+    } catch (err) {
+      console.error('Error recording BrandSync click', err);
+      // continue with redirect if recording fails
+    }
+
+    redirect(data.platform_url);
+  }
+
+  // fallback: token might be an encoded URL
+  try {
+    const targetUrl = decodeBrandSyncToken(params.token);
+
+    if (!/^https?:\/\//i.test(targetUrl)) {
+      redirect("/dashboard/buyer");
+    }
+
+    redirect(targetUrl);
+  } catch {
+    redirect("/dashboard/buyer");
+  }
+}

--- a/src/components/dashboard/brandsync-link-modal.tsx
+++ b/src/components/dashboard/brandsync-link-modal.tsx
@@ -1,0 +1,539 @@
+"use client";
+
+import * as React from "react";
+import { Copy, Link2, Sparkles, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { toast } from "sonner";
+
+type Platform = "YOUTUBE" | "TIKTOK" | "FACEBOOK";
+
+type BrandSyncLinkEntry = {
+  id: number;
+  title: string;
+  platform: Platform;
+  thumbnailUrl?: string | null;
+  brandSyncUrl: string;
+  createdAt: string;
+  shares?: number;
+  isPaid?: boolean;
+  amount?: number;
+};
+
+interface BrandSyncLinkModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function BrandSyncLinkModal({ open, onOpenChange }: BrandSyncLinkModalProps) {
+  const [title, setTitle] = React.useState("");
+  const [platform, setPlatform] = React.useState<Platform>("YOUTUBE");
+  const [videoUrl, setVideoUrl] = React.useState("");
+  const [thumbnailFile, setThumbnailFile] = React.useState<File | null>(null);
+  const [thumbnailName, setThumbnailName] = React.useState("");
+  const [thumbnailPreviewUrl, setThumbnailPreviewUrl] = React.useState<string | null>(null);
+  const [shares, setShares] = React.useState<number>(100);
+  const [requiresPaymentAmount, setRequiresPaymentAmount] = React.useState<number | null>(null);
+  const [pendingBrandSyncId, setPendingBrandSyncId] = React.useState<number | null>(null);
+  const [slipFile, setSlipFile] = React.useState<File | null>(null);
+  const [slipUploadProgress, setSlipUploadProgress] = React.useState<number | null>(null);
+  
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+
+  const readJsonResponse = async (response: Response) => {
+    const text = await response.text();
+
+    if (!text) {
+      return {};
+    }
+
+    try {
+      return JSON.parse(text) as Record<string, unknown>;
+    } catch {
+      return { error: text };
+    }
+  };
+
+  React.useEffect(() => {
+    if (!thumbnailFile) {
+      setThumbnailPreviewUrl(null);
+      return;
+    }
+
+    const previewUrl = URL.createObjectURL(thumbnailFile);
+    setThumbnailPreviewUrl(previewUrl);
+
+    return () => URL.revokeObjectURL(previewUrl);
+  }, [thumbnailFile]);
+
+  const handleTitleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setTitle(e?.target?.value || "");
+  };
+
+  const handleVideoUrlInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setVideoUrl(e?.target?.value || "");
+  };
+
+  const handleSharesInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = Number(e?.target?.value || 0);
+    if (Number.isNaN(v)) return setShares(0);
+    setShares(Math.max(0, Math.floor(v)));
+  };
+
+  const handleThumbnailInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    try {
+      const file = e?.target?.files?.[0] || null;
+      handleThumbnailChange(file);
+    } catch (err) {
+      console.error('Thumbnail input change error', err);
+    }
+  };
+
+  const handleSlipInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    try {
+      const file = e?.target?.files?.[0] || null;
+      handleSlipChange(file);
+    } catch (err) {
+      console.error('Slip input change error', err);
+    }
+  };
+
+  React.useEffect(() => {
+    return;
+  }, [open]);
+
+  const handleThumbnailChange = (file: File | null) => {
+    if (!file) {
+      setThumbnailFile(null);
+      setThumbnailName("");
+      return;
+    }
+
+    setThumbnailFile(file);
+    setThumbnailName(file.name);
+  };
+
+  const handleGenerate = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (!title.trim() || !videoUrl.trim()) {
+      toast.error("Add a title and video URL first");
+      return;
+    }
+
+    try {
+      new URL(videoUrl);
+    } catch {
+      toast.error("Enter a valid video URL");
+      return;
+    }
+
+    // Instead of creating a paid link immediately, create a pending BrandSync row
+    // and reload recent links. Payment is handled separately (bank transfer or gateway).
+    setIsSubmitting(true);
+    try {
+      const payload = {
+        shares: shares ?? 0,
+        title: title.trim(),
+        platform,
+        videoUrl: videoUrl.trim(),
+        createOnly: true,
+      };
+
+      const initResp = await fetch('/api/payment/initialize/brandsync', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      const data = await initResp.json().catch(() => ({}));
+
+      if (!initResp.ok) {
+        toast.error((data.error as string) || 'Failed to create pending BrandSync link');
+        return;
+      }
+
+      const brandsyncId = data.brandsyncId;
+      const amount = data.amount;
+      setPendingBrandSyncId(Number(brandsyncId));
+      setRequiresPaymentAmount(Number(amount));
+
+      // recent links removed: we don't auto-refresh or display them in the modal
+
+      toast.success('Pending BrandSync link created. You can upload a bank slip or wait for payment.');
+      setTitle('');
+      setVideoUrl('');
+      setThumbnailFile(null);
+      setThumbnailName('');
+      setShares(100);
+    } catch (error) {
+      console.error(error);
+      toast.error(error instanceof Error ? error.message : 'Failed to create pending BrandSync link');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleMarkPaid = async () => {
+    // Submit again with paid=true to mark as paid and create the link
+    try {
+      setIsSubmitting(true);
+
+      const formData = new FormData();
+      formData.append("title", title.trim());
+      formData.append("platform", platform);
+      formData.append("videoUrl", videoUrl.trim());
+      formData.append("shares", String(shares ?? 0));
+      formData.append("paid", "true");
+
+      if (thumbnailFile) formData.append("thumbnail", thumbnailFile);
+
+      const response = await fetch("/api/brandsync-links", {
+        method: "POST",
+        credentials: "include",
+        body: formData,
+      });
+
+      const data = await readJsonResponse(response);
+
+      if (!response.ok) {
+        toast.error((data.error as string) || "Failed to create BrandSync link");
+        return;
+      }
+
+      // link created — recent links view removed from modal UI
+
+      toast.success("BrandSync link saved after payment");
+      setTitle("");
+      setVideoUrl("");
+      setThumbnailFile(null);
+      setThumbnailName("");
+      setShares(100);
+      setRequiresPaymentAmount(null);
+    } catch (error) {
+      console.error(error);
+      toast.error(error instanceof Error ? error.message : "Failed to create BrandSync link");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // PayNow flow removed: Generate should create a pending link and payment is handled separately
+
+  const handleCreatePendingForBank = async () => {
+    try {
+      setIsSubmitting(true);
+      const payload = { shares: shares ?? 0, title: title.trim(), platform, videoUrl: videoUrl.trim(), createOnly: true };
+      const res = await fetch('/api/payment/initialize/brandsync', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        toast.error(err?.error || 'Failed to create pending payment');
+        return;
+      }
+
+      const data = await res.json();
+      setPendingBrandSyncId(Number(data.brandsyncId));
+      setRequiresPaymentAmount(Number(data.amount));
+      toast.success('Pending BrandSync created. Upload your bank slip.');
+    } catch (error) {
+      console.error(error);
+      toast.error(error instanceof Error ? error.message : 'Failed to create pending payment');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handlePayPending = async (brandsyncId: number | null) => {
+    if (!brandsyncId) {
+      toast.error('No pending BrandSync to pay');
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      const resp = await fetch(`/api/payment/initialize/brandsync/${brandsyncId}`, { method: 'POST' });
+      if (!resp.ok) {
+        const err = await resp.json().catch(() => ({}));
+        toast.error(err?.error || 'Failed to initialize payment');
+        return;
+      }
+
+      const formData = await resp.json();
+      const paymentForm = document.createElement('form');
+      paymentForm.method = 'post';
+      paymentForm.action = formData.checkout_url;
+      paymentForm.target = '_blank';
+
+      Object.entries(formData).forEach(([key, value]) => {
+        if (value !== undefined && value !== null) {
+          const input = document.createElement('input');
+          input.type = 'hidden';
+          input.name = key;
+          input.value = String(value);
+          paymentForm.appendChild(input);
+        }
+      });
+
+      document.body.appendChild(paymentForm);
+      paymentForm.submit();
+      setTimeout(() => document.body.removeChild(paymentForm), 100);
+
+      toast.success('Opening payment checkout...');
+    } catch (error) {
+      console.error('Pay pending error', error);
+      toast.error('Failed to start payment');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleSlipChange = (file: File | null) => {
+    setSlipFile(file);
+  };
+
+  const handleUploadSlip = async () => {
+    if (!pendingBrandSyncId) {
+      toast.error('Create a pending payment first');
+      return;
+    }
+    if (!slipFile) {
+      toast.error('Please choose a slip file');
+      return;
+    }
+
+    if (!pendingBrandSyncId) {
+      toast.error('Create a pending payment first');
+      return;
+    }
+    try {
+      setIsSubmitting(true);
+      setSlipUploadProgress(0);
+
+      await new Promise<void>((resolve, reject) => {
+        const fd = new FormData();
+        fd.append('slip', slipFile as File);
+
+        const xhr = new XMLHttpRequest();
+        xhr.open('POST', `/api/brandsync-links/${pendingBrandSyncId}/bank-transfer`);
+
+        xhr.upload.onprogress = (ev) => {
+          if (ev.lengthComputable) {
+            const percent = Math.round((ev.loaded / ev.total) * 100);
+            setSlipUploadProgress(percent);
+          }
+        };
+
+        xhr.onload = () => {
+          try {
+            if (xhr.status >= 200 && xhr.status < 300) {
+              resolve();
+            } else {
+              const text = xhr.responseText || `Upload failed: ${xhr.status}`;
+              let parsed: any = null;
+              try { parsed = JSON.parse(text); } catch {}
+              const msg = parsed?.error || parsed?.message || text;
+              reject(new Error(String(msg)));
+            }
+          } catch (e) {
+            reject(e instanceof Error ? e : new Error('Unknown upload error'));
+          }
+        };
+
+        xhr.onerror = () => reject(new Error('Upload network error'));
+
+        xhr.send(fd);
+      });
+
+      toast.success('Slip uploaded. Admin will verify and mark payment.');
+      setSlipFile(null);
+      setPendingBrandSyncId(null);
+      setRequiresPaymentAmount(null);
+    } catch (error) {
+      console.error(error);
+      toast.error(error instanceof Error ? error.message : 'Failed to upload slip');
+    } finally {
+      setIsSubmitting(false);
+      setSlipUploadProgress(null);
+    }
+  };
+
+  const handleCopy = async (link: string) => {
+    await navigator.clipboard.writeText(link);
+    toast.success("BrandSync link copied");
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Sparkles className="h-5 w-5 text-pink-500" />
+            Create BrandSync Link
+          </DialogTitle>
+          <DialogDescription>
+            Follow 2 steps: 1) create the BrandSync link, 2) pay for it online or by bank transfer. The final live link is shown only after payment is accepted.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleGenerate} className="space-y-6">
+          <div className="rounded-xl border p-4 space-y-4 bg-muted/20">
+            <div className="flex items-center gap-2">
+              <div className="flex h-7 w-7 items-center justify-center rounded-full bg-pink-600 text-xs font-bold text-white">1</div>
+              <h3 className="font-semibold">Create your link</h3>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2 sm:col-span-2">
+                <Label htmlFor="brandsync-title">Video Title</Label>
+                <Input
+                  id="brandsync-title"
+                  value={title}
+                  onChange={handleTitleInputChange}
+                  placeholder="Enter a title for the video"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label>Platform</Label>
+                <Select value={platform} onValueChange={(value) => setPlatform(value as Platform)}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Choose platform" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="YOUTUBE">YouTube</SelectItem>
+                    <SelectItem value="TIKTOK">TikTok</SelectItem>
+                    <SelectItem value="FACEBOOK">Facebook</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="brandsync-url">Video URL</Label>
+                <Input
+                  id="brandsync-url"
+                  type="url"
+                  value={videoUrl}
+                  onChange={handleVideoUrlInputChange}
+                  placeholder="https://youtube.com/..."
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="brandsync-shares">Shares Count</Label>
+                <Input
+                  id="brandsync-shares"
+                  type="number"
+                  value={shares}
+                  min={100}
+                  onChange={handleSharesInputChange}
+                  placeholder="Enter number of shares"
+                />
+                <p className="text-xs text-muted-foreground">Minimum 100 shares. Price LKR 6 per share.</p>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="brandsync-thumbnail">Thumbnail</Label>
+              <div className="flex items-center gap-3">
+                <Input
+                  id="brandsync-thumbnail"
+                  type="file"
+                  accept="image/*"
+                  onChange={handleThumbnailInputChange}
+                />
+                {thumbnailFile && (
+                  <Button type="button" variant="ghost" size="sm" onClick={() => handleThumbnailChange(null)}>
+                    <X className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+              {thumbnailName && (
+                <p className="text-xs text-muted-foreground">Selected: {thumbnailName}</p>
+              )}
+            </div>
+
+            {thumbnailPreviewUrl && (
+              <div className="flex items-center gap-3 rounded-lg border border-dashed p-3 bg-background">
+                <img src={thumbnailPreviewUrl} alt="Thumbnail preview" className="h-14 w-14 rounded-md object-cover" />
+                <div className="min-w-0">
+                  <p className="font-medium truncate">{title || "Untitled video"}</p>
+                  <p className="text-xs text-muted-foreground">Thumbnail preview</p>
+                </div>
+              </div>
+            )}
+
+            <Button type="submit" className="w-full bg-pink-600 hover:bg-pink-700 text-white" disabled={isSubmitting}>
+              <Link2 className="mr-2 h-4 w-4" />
+              {isSubmitting ? "Creating link..." : "1. Create link"}
+            </Button>
+          </div>
+
+          <div className="rounded-xl border p-4 space-y-4 bg-muted/20">
+            <div className="flex items-center gap-2">
+              <div className={`flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold text-white ${pendingBrandSyncId ? 'bg-green-600' : 'bg-gray-400'}`}>
+                2
+              </div>
+              <h3 className="font-semibold">Pay for the link</h3>
+            </div>
+
+            <p className="text-sm text-muted-foreground">
+              After Step 1, choose how you want to pay. Pay Online opens PayHere. Bank transfer uploads a slip for admin approval.
+            </p>
+
+            {requiresPaymentAmount !== null && (
+              <p className="text-sm text-red-600 font-medium">Payment required: LKR {requiresPaymentAmount.toLocaleString()}</p>
+            )}
+
+            <div className="flex gap-2 flex-col sm:flex-row">
+              <Button type="button" onClick={() => handlePayPending(pendingBrandSyncId)} disabled={isSubmitting || !pendingBrandSyncId} className="flex-1 bg-green-600 text-white">
+                Pay Online
+              </Button>
+              <Button type="button" onClick={handleMarkPaid} disabled={isSubmitting} className="flex-1">
+                I have paid
+              </Button>
+            </div>
+
+            <div className="border-t pt-3">
+              <p className="text-sm font-medium">Bank transfer</p>
+              <p className="text-xs text-muted-foreground">Create a pending record and upload your transfer slip. The link goes live after admin accepts the payment.</p>
+              <div className="flex gap-2 mt-3 flex-col sm:flex-row">
+                <Button type="button" onClick={handleCreatePendingForBank} disabled={isSubmitting} className="sm:w-auto">
+                  Create Pending
+                </Button>
+                <input type="file" accept="image/*,application/pdf" onChange={handleSlipInputChange} />
+                <Button type="button" onClick={handleUploadSlip} disabled={isSubmitting || !pendingBrandSyncId}>
+                  Upload Slip
+                </Button>
+              </div>
+              {pendingBrandSyncId && <p className="text-xs text-muted-foreground mt-2">Pending ID: {pendingBrandSyncId}</p>}
+              {slipUploadProgress != null && (
+                <div className="mt-2">
+                  <div className="h-2 bg-gray-200 rounded overflow-hidden">
+                    <div className="h-2 bg-pink-600" style={{ width: `${slipUploadProgress}%` }} />
+                  </div>
+                  <p className="text-xs text-muted-foreground">Uploading: {slipUploadProgress}%</p>
+                </div>
+              )}
+            </div>
+
+            {pendingBrandSyncId && (
+              <div className="rounded-lg border border-green-200 bg-green-50 p-3 text-sm text-green-900">
+                Step 2 is ready. Your pending link ID is <span className="font-semibold">{pendingBrandSyncId}</span>.
+              </div>
+            )}
+          </div>
+        </form>
+
+        {/* Recent links removed from modal UI */}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -20,6 +20,7 @@ const deadlineMultipliersSchema = z.object({
 
 const envSchema = z.object({
   // FACEBOOK_ACCESS_TOKEN: z.string().min(1, 'Facebook access token is required'),
+  APP_URL: z.string().url().optional(),
   PLATFORM_RATES: platformRatesSchema.default({
     YOUTUBE: 5,
     FACEBOOK: 3,
@@ -43,6 +44,7 @@ const envSchema = z.object({
 function getEnvVars() {
   const env = {
     // FACEBOOK_ACCESS_TOKEN: process.env.NEXT_PUBLIC_FACEBOOK_ACCESS_TOKEN,
+    APP_URL: process.env.NEXT_PUBLIC_APP_URL,
     PLATFORM_RATES: process.env.NEXT_PUBLIC_PLATFORM_RATES ? 
       JSON.parse(process.env.NEXT_PUBLIC_PLATFORM_RATES) : undefined,
     DEADLINE_MULTIPLIERS: process.env.NEXT_PUBLIC_DEADLINE_MULTIPLIERS ?

--- a/src/lib/utils/brandsync-link.ts
+++ b/src/lib/utils/brandsync-link.ts
@@ -1,0 +1,31 @@
+export function createBrandSyncToken() {
+  const value = crypto.randomUUID().replace(/-/g, "");
+  const encoded = new TextEncoder().encode(value);
+  let binary = "";
+
+  for (const byte of encoded) {
+    binary += String.fromCharCode(byte);
+  }
+
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+export function decodeBrandSyncToken(token: string) {
+  const normalized = token.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
+  const binary = atob(padded);
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+
+  return new TextDecoder().decode(bytes);
+}
+
+export function createBrandSyncLink(token: string) {
+  return `/go/${token}`;
+}
+
+export function buildBrandSyncUrl(origin: string, token: string) {
+  return new URL(createBrandSyncLink(token), origin).toString();
+}

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -199,6 +199,56 @@ export type Database = {
           },
         ]
       }
+      brandsync_links: {
+        Row: {
+          created_at: string
+          id: number
+          platform: Database["public"]["Enums"]["Platforms"]
+          platform_url: string
+          thumbnail_path: string | null
+          shares: number
+          is_paid: boolean
+          amount: number
+          token: string
+          user_id: string
+          title: string
+        }
+        Insert: {
+          created_at?: string
+          id?: number
+          platform: Database["public"]["Enums"]["Platforms"]
+          platform_url: string
+          thumbnail_path?: string | null
+          shares?: number
+          is_paid?: boolean
+          amount?: number
+          token: string
+          user_id: string
+          title: string
+        }
+        Update: {
+          created_at?: string
+          id?: number
+          platform?: Database["public"]["Enums"]["Platforms"]
+          platform_url?: string
+          thumbnail_path?: string | null
+          shares?: number
+          is_paid?: boolean
+          amount?: number
+          token?: string
+          user_id?: string
+          title?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "brandsync_links_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profile"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       contact_details: {
         Row: {
           created_at: string

--- a/src/types/style.d.ts
+++ b/src/types/style.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";


### PR DESCRIPTION
Introduce BrandSync feature: new API endpoints, pages, and UI for creating, paying for, uploading slips, and administering BrandSync links.

Key changes:
- New API routes: brandsync-links (list/create), bank-transfer upload for slips, admin approval endpoint for slips, payment initialization for BrandSync (single and bulk flows), and updated payment notify handler to support ORDER IDs prefixed with BRANDSYNC:.
- Public redirect page (/go/[token]) with click tracking and single-IP protection; error page for link states.
- Buyer and Influencer dashboard UI: list BrandSync links, create modal, upload slip flow with progress, PayHere payment integration, and actions to open/copy links.
- Admin payments page updated to include BrandSync bank-transfer slips and to call the new admin approval endpoint.
- New component BrandSyncLinkModal and supporting utils/types added to handle thumbnail uploads, validations, and link mapping.

These changes add end-to-end support for buyer-created BrandSync links, payment flows (gateway + bank transfer), admin review, and public consumption while enforcing business rules (min shares, paid-only access).