### PR TITLE
Migrate BrandSync bank-transfer handlers

### DIFF
--- a/src/app/api/admin/brandsync-payments/[slipId]/route.ts
+++ b/src/app/api/admin/brandsync-payments/[slipId]/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/lib/supabase-admin';
 import { sendMail } from '@/lib/utils/email';
-import { Database } from '@/types/database.types';
 
-export async function POST(req: NextRequest, { params }: { params: { slipId: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ slipId: string }> }) {
   try {
-    const slipId = Number(params.slipId);
+    const { slipId: slipIdParam } = await params;
+    const slipId = Number(slipIdParam);
     if (!slipId) return NextResponse.json({ error: 'Invalid slip id' }, { status: 400 });
 
     const body = await req.json();
@@ -13,13 +13,19 @@ export async function POST(req: NextRequest, { params }: { params: { slipId: str
     const reason = body.reason as string | undefined;
 
     // Fetch slip and brandsync link
-    const { data: slip } = await supabaseAdmin
-      .from('brandsync_bank_transfer_slips')
-      .select('id, brandsync_id, slip_path, status, created_at')
+    const { data: slip } = await (supabaseAdmin as any)
+      .from('bank_transfer_slip')
+      .select('id, brandsync_id, slip, created_at')
       .eq('id', slipId)
       .single();
 
     if (!slip) return NextResponse.json({ error: 'Slip not found' }, { status: 404 });
+
+    const { data: slipStatus } = await (supabaseAdmin as any)
+      .from('bank_transfer_status')
+      .select('id, status, reviewed_at, reviewed_by, transfer_id')
+      .eq('transfer_id', slipId)
+      .single();
 
     const { data: link } = await supabaseAdmin
       .from('brandsync_links')
@@ -31,10 +37,10 @@ export async function POST(req: NextRequest, { params }: { params: { slipId: str
 
     if (action === 'accept') {
       // mark slip accepted and mark link as paid
-      const { error: u1 } = await supabaseAdmin
-        .from('brandsync_bank_transfer_slips')
-        .update({ status: 'ACCEPTED' })
-        .eq('id', slipId);
+      const { error: u1 } = await (supabaseAdmin as any)
+        .from('bank_transfer_status')
+        .update({ status: 'ACCEPTED', reviewed_at: new Date().toISOString() })
+        .eq('transfer_id', slipId);
       if (u1) throw u1;
 
       const { error: u2 } = await supabaseAdmin
@@ -69,10 +75,10 @@ export async function POST(req: NextRequest, { params }: { params: { slipId: str
       return NextResponse.json({ status: 'ok' });
     } else {
       // reject: mark slip rejected
-      const { error } = await supabaseAdmin
-        .from('brandsync_bank_transfer_slips')
-        .update({ status: 'REJECTED' })
-        .eq('id', slipId);
+      const { error } = await (supabaseAdmin as any)
+        .from('bank_transfer_status')
+        .update({ status: 'REJECTED', reviewed_at: new Date().toISOString() })
+        .eq('transfer_id', slipId);
       if (error) throw error;
 
       // send rejection email

--- a/src/app/api/brandsync-links/[id]/bank-transfer/route.ts
+++ b/src/app/api/brandsync-links/[id]/bank-transfer/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/lib/supabase-admin';
 
-export async function POST(request: Request, { params }: { params: { id: string } }) {
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
+    const { id } = await params;
     const formData = await request.formData();
     const file = formData.get('slip');
 
@@ -10,7 +11,7 @@ export async function POST(request: Request, { params }: { params: { id: string 
       return NextResponse.json({ error: 'No file uploaded' }, { status: 400 });
     }
 
-    const brandsyncId = Number(params.id);
+    const brandsyncId = Number(id);
     if (!brandsyncId) {
       return NextResponse.json({ error: 'Invalid BrandSync ID' }, { status: 400 });
     }
@@ -27,10 +28,10 @@ export async function POST(request: Request, { params }: { params: { id: string 
       return NextResponse.json({ error: 'Failed to upload slip' }, { status: 500 });
     }
 
-    const { data, error: insertError } = await supabaseAdmin
-      .from('brandsync_bank_transfer_slips')
-      .insert({ brandsync_id: brandsyncId, slip_path: filePath })
-      .select('id, brandsync_id, slip_path, status, created_at')
+    const { data, error: insertError } = await (supabaseAdmin as any)
+      .from('bank_transfer_slip')
+      .insert({ brandsync_id: brandsyncId, slip: filePath })
+      .select('id, brandsync_id, slip, created_at')
       .single();
 
     if (insertError) {

--- a/src/app/api/payment/initialize/brandsync/[id]/route.ts
+++ b/src/app/api/payment/initialize/brandsync/[id]/route.ts
@@ -5,14 +5,15 @@ import { Database } from "@/types/database.types";
 import { getPaymentEnvironmentVariables, generatePayHereHash } from "@/lib/utils/payment";
 import { supabaseAdmin } from "@/lib/supabase-admin";
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const id = Number(params.id);
+    const { id: idParam } = await params;
+    const id = Number(idParam);
     if (!id) return NextResponse.json({ error: 'Invalid BrandSync id' }, { status: 400 });
 
     const { data: row, error } = await supabaseAdmin
       .from('brandsync_links')
-      .select('id, title, platform, amount, user_id')
+      .select('id, title, platform, amount, user_id, is_paid')
       .eq('id', id)
       .single();
 

--- a/src/app/api/payment/initialize/brandsync/route.ts
+++ b/src/app/api/payment/initialize/brandsync/route.ts
@@ -4,6 +4,7 @@ import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 import { Database } from "@/types/database.types";
 import { generatePayHereHash, getPaymentEnvironmentVariables } from "@/lib/utils/payment";
 import { supabaseAdmin } from "@/lib/supabase-admin";
+import crypto from 'crypto';
 
 export async function POST(req: NextRequest) {
   try {
@@ -22,7 +23,7 @@ export async function POST(req: NextRequest) {
     const amount = shares * 6; // LKR
 
     // Create pending BrandSync row
-    const { data: created, error: insertError } = await supabaseAdmin
+    const { data: created, error: insertError } = await (supabaseAdmin as any)
       .from('brandsync_links')
       .insert({
         token: crypto.randomUUID().replace(/-/g, ''),
@@ -87,5 +88,3 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: error instanceof Error ? error.message : 'Internal server error' }, { status: 500 });
   }
 }
-
-import crypto from 'crypto';

--- a/src/app/brandsync/error/page.tsx
+++ b/src/app/brandsync/error/page.tsx
@@ -1,9 +1,8 @@
-"use client"
-
 import Link from "next/link";
 
-export default function BrandSyncErrorPage({ searchParams }: { searchParams?: { code?: string } }) {
-  const code = searchParams?.code || '';
+export default async function BrandSyncErrorPage({ searchParams }: { searchParams?: Promise<{ code?: string }> }) {
+  const resolvedSearchParams = (await searchParams) || {};
+  const code = resolvedSearchParams.code || '';
 
   let title = 'Link unavailable';
   let message = 'This BrandSync link is not available.';

--- a/src/app/dashboard/admin/payments/page.tsx
+++ b/src/app/dashboard/admin/payments/page.tsx
@@ -139,20 +139,29 @@ export default function AdminPaymentsPage() {
         status: statuses?.find(status => status.transfer_id === slip.id)
       })) as PaymentWithDetails[];
 
-      // Fetch BrandSync bank transfer slips
-      const { data: bsSlips, error: bsError } = await supabase
-        .from('brandsync_bank_transfer_slips')
-        .select(`*, brandsync:brandsync_links(id, title, amount, user_id)`)
+      // Fetch BrandSync bank transfer slips using the shared bank_transfer_slip table
+      const { data: bsSlips, error: bsError } = await (supabase as any)
+        .from('bank_transfer_slip')
+        .select('*, brandsync_id, brandsync:brandsync_links(id, title, amount, user_id)')
+        .not('brandsync_id', 'is', null)
         .order('created_at', { ascending: false });
 
       if (bsError) throw bsError;
 
+      const brandSyncSlipIds = (bsSlips || []).map((s: any) => s.id);
+      const { data: bsStatuses } = brandSyncSlipIds.length
+        ? await (supabase as any)
+            .from('bank_transfer_status')
+            .select('id, status, reviewed_at, reviewed_by, transfer_id')
+            .in('transfer_id', brandSyncSlipIds)
+        : { data: [] };
+
       const brandSyncPayments = (bsSlips || []).map((s: any) => ({
         id: s.id,
-        slip: s.slip_path,
+        slip: s.slip,
         created_at: s.created_at,
         slipUrl: null,
-        status: { status: s.status, reviewed_at: null, reviewed_by: null },
+        status: bsStatuses?.find((status: any) => status.transfer_id === s.id) || null,
         task: {
           title: s.brandsync?.title || 'BrandSync',
           description: null,

--- a/src/app/go/[token]/page.tsx
+++ b/src/app/go/[token]/page.tsx
@@ -5,12 +5,13 @@ import { headers } from 'next/headers';
 
 export const dynamic = "force-dynamic";
 
-export default async function BrandSyncRedirectPage({ params }: { params: { token: string } }) {
+export default async function BrandSyncRedirectPage({ params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params;
   // try to resolve a stored BrandSync link first (only paid links should be public)
   const { data } = await supabaseAdmin
     .from("brandsync_links")
     .select("id, platform_url, is_paid")
-    .eq("token", params.token)
+    .eq("token", token)
     .maybeSingle();
 
   const hdrs: any = headers();
@@ -50,7 +51,7 @@ export default async function BrandSyncRedirectPage({ params }: { params: { toke
 
   // fallback: token might be an encoded URL
   try {
-    const targetUrl = decodeBrandSyncToken(params.token);
+    const targetUrl = decodeBrandSyncToken(token);
 
     if (!/^https?:\/\//i.test(targetUrl)) {
       redirect("/dashboard/buyer");


### PR DESCRIPTION
Update BrandSync payment handlers and admin UI to use the consolidated bank_transfer tables and async route params. Route handler params are now awaited (Promise<{...}>) where applicable. Replaced references to brandsync_bank_transfer_slips with bank_transfer_slip, renamed slip_path->slip, and moved status tracking into a new bank_transfer_status table (queries/updates now read/write reviewed_at, reviewed_by and transfer_id). Admin payments page updated to fetch slip statuses and use the new slip field. Payment initialization now selects is_paid and imports crypto for token generation. Also adjusted BrandSync error and redirect pages to await search/route params.