### PR TITLE
Add client-side redirect preview component and refactor page

### DIFF
--- a/src/app/go/[token]/BrandSyncRedirectClient.tsx
+++ b/src/app/go/[token]/BrandSyncRedirectClient.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Loader2, ArrowRight, Video } from "lucide-react";
+
+interface BrandSyncRedirectClientProps {
+  token: string;
+  initialTitle: string | null;
+  initialThumbnailUrl: string | null;
+  initialFinalUrl: string | null;
+}
+
+export function BrandSyncRedirectClient({
+  token,
+  initialTitle,
+  initialThumbnailUrl,
+  initialFinalUrl,
+}: BrandSyncRedirectClientProps) {
+  const router = useRouter();
+
+  const [statusMessage, setStatusMessage] = useState(initialThumbnailUrl ? "Link verified!" : "Connecting securely...");
+  const [errorOccurred, setErrorOccurred] = useState(false);
+  
+  // Preview states
+  const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(initialThumbnailUrl);
+  const [campaignTitle, setCampaignTitle] = useState<string | null>(initialTitle);
+  const [redirectUrl, setRedirectUrl] = useState<string | null>(initialFinalUrl);
+  const [countdown, setCountdown] = useState<number>(3);
+
+  useEffect(() => {
+    if (!token) return;
+
+    let active = true;
+
+    const processClick = async () => {
+      try {
+        if (!initialThumbnailUrl) {
+          setStatusMessage("Verifying link connection...");
+        }
+        const response = await fetch("/api/go/click", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ token }),
+        });
+
+        const data = await response.json();
+
+        if (!active) return;
+
+        if (response.ok && data.finalUrl) {
+          setRedirectUrl(data.finalUrl);
+          if (data.thumbnailUrl) {
+            setThumbnailUrl(data.thumbnailUrl);
+            setCampaignTitle(data.title || "Campaign Video");
+            setStatusMessage("Link verified!");
+          } else {
+            setStatusMessage("Redirecting to campaign...");
+            window.location.replace(data.finalUrl);
+          }
+        } else {
+          setErrorOccurred(true);
+          const errCode = data.error;
+          if (errCode === "not_available") {
+            router.replace("/brandsync/error?code=not_available");
+          } else {
+            router.replace("/dashboard/buyer");
+          }
+        }
+      } catch (err) {
+        console.error("Redirection fetch failed:", err);
+        if (active) {
+          setErrorOccurred(true);
+          router.replace("/dashboard/buyer");
+        }
+      }
+    };
+
+    processClick();
+
+    return () => {
+      active = false;
+    };
+  }, [token, router, initialThumbnailUrl]);
+
+  // Handle countdown timer
+  useEffect(() => {
+    if (!redirectUrl || !thumbnailUrl) return;
+
+    if (countdown <= 0) {
+      window.location.replace(redirectUrl);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setCountdown((prev) => prev - 1);
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  }, [countdown, redirectUrl, thumbnailUrl]);
+
+  const handleProceed = () => {
+    if (redirectUrl) {
+      window.location.replace(redirectUrl);
+    }
+  };
+
+  return (
+    <div className="min-h-screen w-full bg-[#fafafa] flex flex-col items-center justify-center relative overflow-hidden font-sans">
+      {/* Subtle Background Accent */}
+      <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[500px] h-[500px] rounded-full bg-pink-500/[0.03] blur-[120px] pointer-events-none" />
+
+      {/* Main Container */}
+      <div className="w-[90%] max-w-sm bg-white border border-gray-100 p-6 sm:p-8 rounded-2xl shadow-sm flex flex-col items-center text-center z-10">
+        
+        {/* Brand Logo Container */}
+        <div className="w-12 h-12 rounded-xl bg-white border border-gray-100 flex items-center justify-center p-2 mb-4 shadow-sm">
+          <img src="/logo.png" alt="BrandSync Platform" className="object-contain w-full h-full" />
+        </div>
+
+        {/* BrandSync Brand Title */}
+        <h2 className="text-gray-900 text-sm font-bold tracking-wide mb-0.5">BrandSync Platform</h2>
+        <p className="text-gray-400 text-[10px] mb-6">Secure Campaign Redirect System</p>
+
+        {thumbnailUrl ? (
+          // Thumbnail Preview UI
+          <div className="w-full flex flex-col items-center animate-fade-in">
+            <div className="w-full aspect-video rounded-xl overflow-hidden border border-gray-100 shadow-inner relative group mb-4">
+              <img 
+                src={thumbnailUrl} 
+                alt={campaignTitle || "Campaign Thumbnail"} 
+                className="w-full h-full object-cover"
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent flex items-end p-3">
+                <span className="text-white text-[9px] font-bold uppercase tracking-wider px-2 py-0.75 bg-black/45 backdrop-blur rounded-md flex items-center gap-1">
+                  <Video className="w-3 h-3 text-pink-500" /> Preview
+                </span>
+              </div>
+            </div>
+
+            <h3 className="text-gray-900 text-sm font-bold line-clamp-2 px-1 mb-1">
+              {campaignTitle}
+            </h3>
+            <p className="text-xs text-gray-500 mb-6">
+              Redirecting to video in <span className="font-bold text-[#C8185A]">{countdown}s</span>...
+            </p>
+
+            <button 
+              onClick={handleProceed}
+              className="w-full bg-[#C8185A] text-white hover:bg-[#A61048] flex items-center justify-center gap-1.5 py-2.5 rounded-xl text-xs font-bold shadow-sm transition-all active:scale-98"
+            >
+              Proceed to Video
+              <ArrowRight className="w-4 h-4" />
+            </button>
+          </div>
+        ) : (
+          // Original Spinner UI
+          <div className="w-full flex flex-col items-center">
+            {/* Loading Spinner / Arrow Indicator */}
+            <div className="relative w-16 h-16 flex items-center justify-center mb-6">
+              <div className="absolute inset-0 border border-gray-100 rounded-full" />
+
+              {errorOccurred ? (
+                <div className="w-10 h-10 rounded-full bg-red-50 flex items-center justify-center text-red-500">
+                  <ArrowRight className="h-5 w-5" />
+                </div>
+              ) : (
+                <>
+                  {/* Spinning gradient ring */}
+                  <div className="absolute inset-0 border-2 border-transparent border-t-[#C8185A] rounded-full animate-spin" />
+                  <Loader2 className="h-5 w-5 text-[#C8185A] animate-spin" />
+                </>
+              )}
+            </div>
+
+            {/* Dynamic Status Text */}
+            <p className="text-xs font-semibold text-gray-700 tracking-wide mb-2 transition-all duration-300">
+              {statusMessage}
+            </p>
+
+            {/* Progress Dots */}
+            {!errorOccurred && (
+              <div className="flex gap-1 items-center justify-center">
+                <span className="w-1.5 h-1.5 rounded-full bg-[#C8185A] animate-bounce [animation-delay:-0.3s]" />
+                <span className="w-1.5 h-1.5 rounded-full bg-[#C8185A]/75 animate-bounce [animation-delay:-0.15s]" />
+                <span className="w-1.5 h-1.5 rounded-full bg-[#C8185A]/45 animate-bounce" />
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Footer Info */}
+      <p className="absolute bottom-6 text-[9px] text-gray-400 font-bold tracking-widest uppercase">
+        Secured by BrandSync Link-Shield
+      </p>
+    </div>
+  );
+}

--- a/src/app/go/[token]/page.tsx
+++ b/src/app/go/[token]/page.tsx
@@ -1,123 +1,102 @@
-"use client";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { BrandSyncRedirectClient } from "./BrandSyncRedirectClient";
+import type { Metadata } from "next";
 
-import { use, useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
-import { Loader2, ArrowRight } from "lucide-react";
+async function getLinkDetails(token: string) {
+  if (!token) return null;
 
-export default function BrandSyncRedirectPage({ params }: { params: Promise<{ token: string }> }) {
-  const router = useRouter();
-  const resolvedParams = use(params);
-  const token = resolvedParams.token;
+  try {
+    // 1. Check if it's an influencer sub-token
+    const { data: subToken } = await (supabaseAdmin as any)
+      .from('brandsync_influencer_tokens')
+      .select('id, brandsync_id')
+      .eq('token', token)
+      .maybeSingle();
 
-  const [statusMessage, setStatusMessage] = useState("Connecting securely...");
-  const [errorOccurred, setErrorOccurred] = useState(false);
+    let parentLink = null;
+    if (subToken) {
+      const { data } = await supabaseAdmin
+        .from('brandsync_links')
+        .select('platform_url, is_paid, title, thumbnail_path')
+        .eq('id', subToken.brandsync_id)
+        .maybeSingle();
+      parentLink = data;
+    } else {
+      // 2. Check if it's a direct link
+      const { data } = await supabaseAdmin
+        .from('brandsync_links')
+        .select('platform_url, is_paid, title, thumbnail_path')
+        .eq('token', token)
+        .maybeSingle();
+      parentLink = data;
+    }
 
-  useEffect(() => {
-    if (!token) return;
+    if (!parentLink) return null;
 
-    let active = true;
+    let thumbnailUrl = null;
+    if (parentLink.thumbnail_path) {
+      const { data: signRes } = await supabaseAdmin.storage
+        .from("proof-images")
+        .createSignedUrl(parentLink.thumbnail_path, 60 * 60 * 24); // 1 day
+      thumbnailUrl = signRes?.signedUrl || null;
+    }
 
-    const processClick = async () => {
-      try {
-        setStatusMessage("Verifying link connection...");
-        const response = await fetch("/api/go/click", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ token }),
-        });
+    let finalUrl = parentLink.platform_url;
+    if (finalUrl && !/^https?:\/\//i.test(finalUrl)) {
+      finalUrl = "https://" + finalUrl;
+    }
 
-        const data = await response.json();
-
-        if (!active) return;
-
-        if (response.ok && data.finalUrl) {
-          setStatusMessage("Redirecting to campaign...");
-          // Use replace to avoid keeping the redirect page in browser history
-          window.location.replace(data.finalUrl);
-        } else {
-          setErrorOccurred(true);
-          const errCode = data.error;
-          if (errCode === "not_available") {
-            router.replace("/brandsync/error?code=not_available");
-          } else {
-            router.replace("/dashboard/buyer");
-          }
-        }
-      } catch (err) {
-        console.error("Redirection fetch failed:", err);
-        if (active) {
-          setErrorOccurred(true);
-          router.replace("/dashboard/buyer");
-        }
-      }
+    return {
+      title: parentLink.title,
+      thumbnailUrl,
+      finalUrl,
+      isPaid: parentLink.is_paid
     };
+  } catch (err) {
+    console.error("Error in getLinkDetails:", err);
+    return null;
+  }
+}
 
-    // A small timeout to make the transitions smooth and give a premium feel
-    const timer = setTimeout(() => {
-      processClick();
-    }, 600);
+export async function generateMetadata({ params }: { params: Promise<{ token: string }> }): Promise<Metadata> {
+  const { token } = await params;
+  const details = await getLinkDetails(token);
 
-    return () => {
-      active = false;
-      clearTimeout(timer);
+  if (!details) {
+    return {
+      title: "BrandSync Platform",
+      description: "Secure Campaign Redirect System",
     };
-  }, [token, router]);
+  }
+
+  return {
+    title: details.title,
+    description: "Watch this campaign video on BrandSync",
+    openGraph: {
+      title: details.title,
+      description: "Watch this campaign video on BrandSync",
+      images: details.thumbnailUrl ? [{ url: details.thumbnailUrl }] : [],
+      type: "video.other",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: details.title,
+      description: "Watch this campaign video on BrandSync",
+      images: details.thumbnailUrl ? [details.thumbnailUrl] : [],
+    }
+  };
+}
+
+export default async function BrandSyncRedirectPage({ params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params;
+  const details = await getLinkDetails(token);
 
   return (
-    <div className="min-h-screen w-full bg-[#fafafa] flex flex-col items-center justify-center relative overflow-hidden font-sans">
-      {/* Subtle Background Accent */}
-      <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[500px] h-[500px] rounded-full bg-pink-500/[0.03] blur-[120px] pointer-events-none" />
-
-      {/* Main Container */}
-      <div className="w-[90%] max-w-sm bg-white border border-gray-100 p-8 rounded-2xl shadow-sm flex flex-col items-center text-center z-10">
-
-        {/* Brand Logo Container */}
-        <div className="w-14 h-14 rounded-xl bg-white border border-gray-100 flex items-center justify-center p-2.5 mb-5 shadow-sm">
-          <img src="/logo.png" alt="BrandSync Platform" className="object-contain w-full h-full" />
-        </div>
-
-        {/* BrandSync Brand Title */}
-        <h2 className="text-gray-900 text-base font-bold tracking-wide mb-1">BrandSync Platform</h2>
-        <p className="text-gray-400 text-[11px] mb-8">Secure Campaign Redirect System</p>
-
-        {/* Loading Spinner / Arrow Indicator */}
-        <div className="relative w-16 h-16 flex items-center justify-center mb-8">
-          <div className="absolute inset-0 border border-gray-100 rounded-full" />
-
-          {errorOccurred ? (
-            <div className="w-10 h-10 rounded-full bg-red-50 flex items-center justify-center text-red-500">
-              <ArrowRight className="h-5 w-5" />
-            </div>
-          ) : (
-            <>
-              {/* Spinning gradient ring */}
-              <div className="absolute inset-0 border-2 border-transparent border-t-[#C8185A] rounded-full animate-spin" />
-              <Loader2 className="h-5 w-5 text-[#C8185A] animate-spin" />
-            </>
-          )}
-        </div>
-
-        {/* Dynamic Status Text */}
-        <p className="text-xs font-semibold text-gray-700 tracking-wide mb-2 transition-all duration-300">
-          {statusMessage}
-        </p>
-
-        {/* Progress Dots */}
-        {!errorOccurred && (
-          <div className="flex gap-1 items-center justify-center">
-            <span className="w-1.5 h-1.5 rounded-full bg-[#C8185A] animate-bounce [animation-delay:-0.3s]" />
-            <span className="w-1.5 h-1.5 rounded-full bg-[#C8185A]/75 animate-bounce [animation-delay:-0.15s]" />
-            <span className="w-1.5 h-1.5 rounded-full bg-[#C8185A]/45 animate-bounce" />
-          </div>
-        )}
-      </div>
-
-      {/* Footer Info */}
-      <p className="absolute bottom-6 text-[9px] text-gray-400 font-bold tracking-widest uppercase">
-        Secured by BrandSync Link-Shield
-      </p>
-    </div>
+    <BrandSyncRedirectClient
+      token={token}
+      initialTitle={details?.title || null}
+      initialThumbnailUrl={details?.thumbnailUrl || null}
+      initialFinalUrl={details?.finalUrl || null}
+    />
   );
 }


### PR DESCRIPTION
This pull request refactors the BrandSync campaign redirect page to use server-side rendering for link metadata and initial campaign details, and moves all client-side logic and UI into a dedicated `BrandSyncRedirectClient` component. This results in improved SEO, more reliable metadata for social sharing, and a cleaner separation of concerns between server and client code.

**Server-side improvements:**
- The main page (`page.tsx`) now fetches campaign details and generates Open Graph/Twitter metadata on the server, supporting better SEO and link previews. ([src/app/go/[token]/page.tsxL1-R100](diffhunk://#diff-8e06a26fdb83cc2d2cb0fa19dbf87be21c604dbc6b9ac63553b3d07fc12b5ce2L1-R100))
- The initial campaign data (title, thumbnail, final URL) is passed as props to the client component, ensuring a smooth and secure client-side experience. ([src/app/go/[token]/page.tsxL1-R100](diffhunk://#diff-8e06a26fdb83cc2d2cb0fa19dbf87be21c604dbc6b9ac63553b3d07fc12b5ce2L1-R100))

**Client-side UI/UX enhancements:**
- All redirect logic, status handling, countdown, and UI rendering are encapsulated in the new `BrandSyncRedirectClient` React component. ([src/app/go/[token]/BrandSyncRedirectClient.tsxR1-R201](diffhunk://#diff-d2c02f3f5901e9797347f4839cd7893e2bda0d54c43cbd188934616284b70eefR1-R201))
- The client component provides improved feedback with a video preview, countdown timer, and error handling, and handles the redirect process securely. ([src/app/go/[token]/BrandSyncRedirectClient.tsxR1-R201](diffhunk://#diff-d2c02f3f5901e9797347f4839cd7893e2bda0d54c43cbd188934616284b70eefR1-R201))

**Code organization:**
- Removes legacy client-side logic and UI from `page.tsx`, making the codebase more maintainable and modular. ([src/app/go/[token]/page.tsxL1-R100](diffhunk://#diff-8e06a26fdb83cc2d2cb0fa19dbf87be21c604dbc6b9ac63553b3d07fc12b5ce2L1-R100), [src/app/go/[token]/BrandSyncRedirectClient.tsxR1-R201](diffhunk://#diff-d2c02f3f5901e9797347f4839cd7893e2bda0d54c43cbd188934616284b70eefR1-R201))