### PR TITLE
Add unlock cooldown timer and nextUnlockAt metadata

### DIFF
--- a/src/app/api/brandsync-links/[id]/influencer-token/route.ts
+++ b/src/app/api/brandsync-links/[id]/influencer-token/route.ts
@@ -67,7 +67,22 @@ export async function GET(
       return NextResponse.json({ uniqueUrl, token: existing.token, unlocked: true });
     }
 
-    return NextResponse.json({ unlocked: false });
+    // Get unlock limits metadata
+    const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    const { data: recentTokens } = await (supabaseAdmin as any)
+      .from("brandsync_influencer_tokens")
+      .select("created_at")
+      .eq("influencer_user_id", user.id)
+      .gte("created_at", twentyFourHoursAgo)
+      .order("created_at", { ascending: true });
+
+    const reachedLimit = recentTokens && recentTokens.length >= 3;
+    let nextUnlockAt = null;
+    if (reachedLimit && recentTokens && recentTokens[0]) {
+      nextUnlockAt = new Date(new Date(recentTokens[0].created_at).getTime() + 24 * 60 * 60 * 1000).toISOString();
+    }
+
+    return NextResponse.json({ unlocked: false, nextUnlockAt });
   } catch (error) {
     console.error("Influencer token check error:", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
@@ -129,8 +144,22 @@ export async function POST(
       }
 
       if (createdTodayCount && createdTodayCount >= 3) {
+        // Find the oldest of the last 3 unlocks
+        const { data: oldestToken } = await (supabaseAdmin as any)
+          .from("brandsync_influencer_tokens")
+          .select("created_at")
+          .eq("influencer_user_id", user.id)
+          .gte("created_at", twentyFourHoursAgo)
+          .order("created_at", { ascending: true })
+          .limit(1)
+          .maybeSingle();
+
+        const nextUnlockAt = oldestToken 
+          ? new Date(new Date(oldestToken.created_at).getTime() + 24 * 60 * 60 * 1000).toISOString()
+          : new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+
         return NextResponse.json(
-          { error: "daily_limit_reached", message: "You have reached your daily limit of 3 unlocked links." },
+          { error: "daily_limit_reached", message: "You have reached your daily limit of 3 unlocked links.", nextUnlockAt },
           { status: 403 }
         );
       }

--- a/src/app/dashboard/influencer/links/page.tsx
+++ b/src/app/dashboard/influencer/links/page.tsx
@@ -30,6 +30,78 @@ type BrandSyncLinkEntry = {
   myClicks?: number;
   shares?: number;
   unlocked?: boolean;
+  nextUnlockAt?: string | null;
+};
+
+const UnlockButtonWithCountdown = ({ 
+  linkId, 
+  nextUnlockAt, 
+  isUnlocking, 
+  onUnlock 
+}: { 
+  linkId: number; 
+  nextUnlockAt?: string | null; 
+  isUnlocking: boolean; 
+  onUnlock: () => void;
+}) => {
+  const [timeLeft, setTimeLeft] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!nextUnlockAt) {
+      setTimeLeft(null);
+      return;
+    }
+
+    const updateTimer = () => {
+      const diff = new Date(nextUnlockAt).getTime() - Date.now();
+      if (diff <= 0) {
+        setTimeLeft(null);
+        return;
+      }
+      const h = Math.floor(diff / 3600000);
+      const m = Math.floor((diff % 3600000) / 60000);
+      const s = Math.floor((diff % 60000) / 1000);
+      
+      const formatted = [
+        h > 0 ? `${h}h` : null,
+        m > 0 || h > 0 ? `${m}m` : null,
+        `${s}s`
+      ].filter(Boolean).join(" ");
+      
+      setTimeLeft(formatted);
+    };
+
+    updateTimer();
+    const timer = setInterval(updateTimer, 1000);
+    return () => clearInterval(timer);
+  }, [nextUnlockAt]);
+
+  const isDisabled = isUnlocking || !!timeLeft;
+  const PINK = "#C8185A";
+
+  return (
+    <Button
+      className="w-full text-xs h-8 font-semibold text-white shadow-sm flex items-center justify-center gap-1.5 transition-all"
+      style={{ background: PINK }}
+      disabled={isDisabled}
+      onClick={onUnlock}
+    >
+      {isUnlocking ? (
+        <>
+          <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white border-t-transparent" />
+          Unlocking...
+        </>
+      ) : timeLeft ? (
+        <>
+          <Lock className="h-3.5 w-3.5" /> Unlock in {timeLeft}
+        </>
+      ) : (
+        <>
+          <Lock className="h-3.5 w-3.5" /> Unlock Task Link
+        </>
+      )}
+    </Button>
+  );
 };
 
 export default function InfluencerLinksPage() {
@@ -51,6 +123,13 @@ export default function InfluencerLinksPage() {
       if (!res.ok) {
         if (data.error === "daily_limit_reached") {
           toast.error("Daily limit reached! You can only unlock 3 links per day.");
+          if (data.nextUnlockAt) {
+            setBrandSyncLinks(prev => prev.map(link => 
+              !link.unlocked 
+                ? { ...link, nextUnlockAt: data.nextUnlockAt } 
+                : link
+            ));
+          }
         } else {
           toast.error(data.error || "Failed to unlock link.");
         }
@@ -91,6 +170,8 @@ export default function InfluencerLinksPage() {
                 const data = await tokenResp.json();
                 if (data.unlocked) {
                   return { ...link, uniqueUrl: data.uniqueUrl as string, unlocked: true };
+                } else {
+                  return { ...link, uniqueUrl: null, unlocked: false, nextUnlockAt: data.nextUnlockAt };
                 }
               }
             } catch {}
@@ -179,23 +260,12 @@ export default function InfluencerLinksPage() {
                         {/* Actions */}
                         <div className="flex items-center gap-2 w-full">
                           {!link.unlocked ? (
-                            <Button
-                              className="w-full text-xs h-8 font-semibold text-white shadow-sm flex items-center justify-center gap-1.5 transition-all"
-                              style={{ background: PINK }}
-                              disabled={isUnlocking === link.id}
-                              onClick={() => handleUnlockLink(link.id)}
-                            >
-                              {isUnlocking === link.id ? (
-                                <>
-                                  <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white border-t-transparent" />
-                                  Unlocking...
-                                </>
-                              ) : (
-                                <>
-                                  <Lock className="h-3.5 w-3.5" /> Unlock Task Link
-                                </>
-                              )}
-                            </Button>
+                            <UnlockButtonWithCountdown
+                              linkId={link.id}
+                              nextUnlockAt={link.nextUnlockAt}
+                              isUnlocking={isUnlocking === link.id}
+                              onUnlock={() => handleUnlockLink(link.id)}
+                            />
                           ) : (
                             <>
                               <Button

--- a/src/app/dashboard/influencer/page.tsx
+++ b/src/app/dashboard/influencer/page.tsx
@@ -106,6 +106,78 @@ type BrandSyncLinkEntry = {
   myClicks?: number;
   shares?: number;
   unlocked?: boolean;
+  nextUnlockAt?: string | null;
+};
+
+const UnlockButtonWithCountdown = ({ 
+  linkId, 
+  nextUnlockAt, 
+  isUnlocking, 
+  onUnlock 
+}: { 
+  linkId: number; 
+  nextUnlockAt?: string | null; 
+  isUnlocking: boolean; 
+  onUnlock: () => void;
+}) => {
+  const [timeLeft, setTimeLeft] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!nextUnlockAt) {
+      setTimeLeft(null);
+      return;
+    }
+
+    const updateTimer = () => {
+      const diff = new Date(nextUnlockAt).getTime() - Date.now();
+      if (diff <= 0) {
+        setTimeLeft(null);
+        return;
+      }
+      const h = Math.floor(diff / 3600000);
+      const m = Math.floor((diff % 3600000) / 60000);
+      const s = Math.floor((diff % 60000) / 1000);
+      
+      const formatted = [
+        h > 0 ? `${h}h` : null,
+        m > 0 || h > 0 ? `${m}m` : null,
+        `${s}s`
+      ].filter(Boolean).join(" ");
+      
+      setTimeLeft(formatted);
+    };
+
+    updateTimer();
+    const timer = setInterval(updateTimer, 1000);
+    return () => clearInterval(timer);
+  }, [nextUnlockAt]);
+
+  const isDisabled = isUnlocking || !!timeLeft;
+  const PINK = "#C8185A";
+
+  return (
+    <Button
+      className="w-full text-xs h-8 font-semibold text-white shadow-sm flex items-center justify-center gap-1.5 transition-all"
+      style={{ background: PINK }}
+      disabled={isDisabled}
+      onClick={onUnlock}
+    >
+      {isUnlocking ? (
+        <>
+          <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white border-t-transparent" />
+          Unlocking...
+        </>
+      ) : timeLeft ? (
+        <>
+          <Lock className="h-3.5 w-3.5" /> Unlock in {timeLeft}
+        </>
+      ) : (
+        <>
+          <Lock className="h-3.5 w-3.5" /> Unlock Task Link
+        </>
+      )}
+    </Button>
+  );
 };
 
 export default function InfluencerDashboardPage() {
@@ -169,6 +241,13 @@ export default function InfluencerDashboardPage() {
       if (!res.ok) {
         if (data.error === "daily_limit_reached") {
           toast.error("Daily limit reached! You can only unlock 3 links per day.");
+          if (data.nextUnlockAt) {
+            setBrandSyncLinks(prev => prev.map(link => 
+              !link.unlocked 
+                ? { ...link, nextUnlockAt: data.nextUnlockAt } 
+                : link
+            ));
+          }
         } else {
           toast.error(data.error || "Failed to unlock link.");
         }
@@ -234,6 +313,8 @@ export default function InfluencerDashboardPage() {
                       const data = await tokenResp.json();
                       if (data.unlocked) {
                         return { ...link, uniqueUrl: data.uniqueUrl as string, unlocked: true };
+                      } else {
+                        return { ...link, uniqueUrl: null, unlocked: false, nextUnlockAt: data.nextUnlockAt };
                       }
                     }
                   } catch {}
@@ -489,23 +570,12 @@ export default function InfluencerDashboardPage() {
                             ) : null}
                             <div className="flex items-center gap-2 w-full">
                               {!link.unlocked ? (
-                                <Button
-                                  className="w-full text-xs h-8 font-semibold text-white shadow-sm flex items-center justify-center gap-1.5 transition-all"
-                                  style={{ background: PINK }}
-                                  disabled={isUnlocking === link.id}
-                                  onClick={() => handleUnlockLink(link.id)}
-                                >
-                                  {isUnlocking === link.id ? (
-                                    <>
-                                      <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white border-t-transparent" />
-                                      Unlocking...
-                                    </>
-                                  ) : (
-                                    <>
-                                      <Lock className="h-3.5 w-3.5" /> Unlock Task Link
-                                    </>
-                                  )}
-                                </Button>
+                                <UnlockButtonWithCountdown
+                                  linkId={link.id}
+                                  nextUnlockAt={link.nextUnlockAt}
+                                  isUnlocking={isUnlocking === link.id}
+                                  onUnlock={() => handleUnlockLink(link.id)}
+                                />
                               ) : (
                                 <>
                                   <Button


### PR DESCRIPTION
Enforce and surface the 3-per-24h unlock limit by computing a nextUnlockAt timestamp server-side and showing a cooldown on the UI. Server: query recent influencer tokens (last 24h) to detect limit reach, compute nextUnlockAt from the oldest of the recent tokens, and include nextUnlockAt in both GET and POST responses when the daily limit is hit. Frontend: add nextUnlockAt to BrandSyncLinkEntry, introduce UnlockButtonWithCountdown (shared pattern added to influencer links and dashboard pages) which disables the unlock button and displays a live countdown until the next unlock is available. Also update unlock error handling to populate links with nextUnlockAt when the API returns the daily_limit_reached response.