### PR TITLE
Add influencer bonus flow and campaign limits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@tsparticles/slim": "^3.8.1",
         "@types/nodemailer": "^6.4.17",
         "@types/uuid": "^10.0.0",
-        "@vercel/analytics": "^1.5.0",
+        "@vercel/analytics": "^1.6.1",
         "axios": "^1.8.4",
         "cheerio": "^1.0.0",
         "class-variance-authority": "^0.7.1",
@@ -44,6 +44,7 @@
         "react-day-picker": "^8.10.1",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.55.0",
+        "react-is": "^19.2.6",
         "recharts": "^3.8.1",
         "sonner": "^2.0.3",
         "tailwind-merge": "^3.2.0",
@@ -2932,9 +2933,9 @@
       }
     },
     "node_modules/@vercel/analytics": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
-      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz",
+      "integrity": "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==",
       "license": "MPL-2.0",
       "peerDependencies": {
         "@remix-run/react": "^2",
@@ -4624,6 +4625,12 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
+    },
+    "node_modules/react-is": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@tsparticles/slim": "^3.8.1",
     "@types/nodemailer": "^6.4.17",
     "@types/uuid": "^10.0.0",
-    "@vercel/analytics": "^1.5.0",
+    "@vercel/analytics": "^1.6.1",
     "axios": "^1.8.4",
     "cheerio": "^1.0.0",
     "class-variance-authority": "^0.7.1",

--- a/src/app/api/brandsync-links/[id]/influencer-token/route.ts
+++ b/src/app/api/brandsync-links/[id]/influencer-token/route.ts
@@ -108,7 +108,7 @@ export async function POST(
     // Verify the parent brandsync link exists and is paid
     const { data: parent, error: parentError } = await supabaseAdmin
       .from("brandsync_links")
-      .select("id, title, platform, thumbnail_path, is_paid")
+      .select("id, title, platform, thumbnail_path, is_paid, shares")
       .eq("id", brandsyncId)
       .eq("is_paid", true)
       .maybeSingle();
@@ -117,6 +117,14 @@ export async function POST(
       return NextResponse.json({ error: "BrandSync link not found or not active" }, { status: 404 });
     }
 
+    // Fetch total campaign clicks count
+    const { count: totalClicksCount } = await (supabaseAdmin as any)
+      .from("brandsync_clicks")
+      .select("id", { count: "exact", head: true })
+      .eq("brandsync_id", brandsyncId);
+
+    const isFull = typeof totalClicksCount === "number" && typeof parent.shares === "number" && totalClicksCount >= parent.shares;
+
     // Check for an existing sub-token for this influencer
     const { data: existing } = await (supabaseAdmin as any)
       .from("brandsync_influencer_tokens")
@@ -124,6 +132,10 @@ export async function POST(
       .eq("brandsync_id", brandsyncId)
       .eq("influencer_user_id", user.id)
       .maybeSingle();
+
+    if (isFull && !existing?.token) {
+      return NextResponse.json({ error: "campaign_full", message: "This campaign is already full." }, { status: 400 });
+    }
 
     let token: string;
 

--- a/src/app/api/go/click/route.ts
+++ b/src/app/api/go/click/route.ts
@@ -74,6 +74,12 @@ export async function POST(request: Request) {
             .update({ clicked_at: new Date().toISOString(), ip_address: ip })
             .eq('id', subToken.id);
 
+          // Fetch total campaign clicks count
+          const { count: totalClicksCount } = await (supabaseAdmin as any)
+            .from('brandsync_clicks')
+            .select('id', { count: 'exact', head: true })
+            .eq('brandsync_id', subToken.brandsync_id);
+
           // Milestone balance credit
           const { count: clicksCount } = await (supabaseAdmin as any)
             .from('brandsync_clicks')
@@ -82,7 +88,8 @@ export async function POST(request: Request) {
 
           if (clicksCount && clicksCount > 0 && clicksCount % 10 === 0) {
             const limit = parent.shares || 0;
-            if (clicksCount <= limit) {
+            const totalClicksVal = totalClicksCount || 0;
+            if (clicksCount <= limit && totalClicksVal <= limit) {
               const lkrPerUsd = Number(process.env.NEXT_PUBLIC_LKR_PER_USD || process.env.LKR_PER_USD || 295);
               const reward = 0.01 * lkrPerUsd;
 

--- a/src/app/api/influencer/claim-bonus/route.ts
+++ b/src/app/api/influencer/claim-bonus/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import type { Database } from "@/types/database.types";
+
+async function getCurrentUser() {
+  const cookieStore = await cookies();
+  const supabase = createRouteHandlerClient<Database>({ cookies: () => cookieStore as any });
+  const { data: { user }, error } = await supabase.auth.getUser();
+  if (error || !user) return null;
+  return user;
+}
+
+export async function POST(request: Request) {
+  try {
+    const user = await getCurrentUser();
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Verify user is an influencer
+    const { data: profile, error: profileErr } = await supabaseAdmin
+      .from('profile')
+      .select('role')
+      .eq('id', user.id)
+      .maybeSingle();
+
+    if (profileErr || !profile) {
+      return NextResponse.json({ error: "Profile not found" }, { status: 404 });
+    }
+
+    const isInfluencer = profile.role?.includes('INFLUENCER');
+    if (!isInfluencer) {
+      return NextResponse.json({ error: "Only influencers can claim signup bonus" }, { status: 403 });
+    }
+
+    // Check if they already have account balance record and total_earning > 0
+    const { data: currentBalance, error: balErr } = await supabaseAdmin
+      .from('account_balance')
+      .select('*')
+      .eq('user_id', user.id)
+      .maybeSingle();
+
+    if (balErr) {
+      console.error("Failed to query account balance:", balErr);
+      return NextResponse.json({ error: "Database error" }, { status: 500 });
+    }
+
+    if (currentBalance && currentBalance.total_earning > 0) {
+      return NextResponse.json({ error: "not_eligible", message: "You have already claimed your signup bonus or earned rewards." }, { status: 400 });
+    }
+
+    const lkrPerUsd = Number(process.env.NEXT_PUBLIC_LKR_PER_USD || process.env.LKR_PER_USD || 295);
+    const bonusLKR = 1 * lkrPerUsd;
+
+    let updatedBalance;
+    if (currentBalance) {
+      // Update
+      const { data: updated, error: updateErr } = await supabaseAdmin
+        .from('account_balance')
+        .update({
+          balance: currentBalance.balance + bonusLKR,
+          total_earning: currentBalance.total_earning + bonusLKR
+        })
+        .eq('user_id', user.id)
+        .select()
+        .maybeSingle();
+
+      if (updateErr || !updated) {
+        console.error("Failed to update balance:", updateErr);
+        return NextResponse.json({ error: "Failed to update balance" }, { status: 500 });
+      }
+      updatedBalance = updated;
+    } else {
+      // Insert
+      const { data: inserted, error: insertErr } = await supabaseAdmin
+        .from('account_balance')
+        .insert({
+          user_id: user.id,
+          balance: bonusLKR,
+          total_earning: bonusLKR
+        })
+        .select()
+        .maybeSingle();
+
+      if (insertErr || !inserted) {
+        console.error("Failed to insert balance:", insertErr);
+        return NextResponse.json({ error: "Failed to create balance" }, { status: 500 });
+      }
+      updatedBalance = inserted;
+    }
+
+    return NextResponse.json({ success: true, balance: updatedBalance });
+  } catch (error) {
+    console.error("Claim bonus api error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/influencer/links/page.tsx
+++ b/src/app/dashboard/influencer/links/page.tsx
@@ -259,7 +259,14 @@ export default function InfluencerLinksPage() {
 
                         {/* Actions */}
                         <div className="flex items-center gap-2 w-full">
-                          {!link.unlocked ? (
+                          {typeof link.clicks === "number" && typeof link.shares === "number" && link.clicks >= link.shares ? (
+                            <Button
+                              className="w-full text-xs h-8 font-semibold text-gray-400 bg-gray-100 border border-gray-200 cursor-not-allowed flex items-center justify-center gap-1.5 transition-all shadow-none"
+                              disabled
+                            >
+                              Campaign Full
+                            </Button>
+                          ) : !link.unlocked ? (
                             <UnlockButtonWithCountdown
                               linkId={link.id}
                               nextUnlockAt={link.nextUnlockAt}

--- a/src/app/dashboard/influencer/page.tsx
+++ b/src/app/dashboard/influencer/page.tsx
@@ -9,6 +9,7 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { motion } from "framer-motion";
 import Link from "next/link";
 import { InfluencerTaskCard } from "@/components/dashboard/influencer-task-card";
+import { GiftBonusModal } from "@/components/dashboard/gift-bonus-modal";
 import {
   ChevronsLeft,
   ChevronsRight,
@@ -206,6 +207,7 @@ export default function InfluencerDashboardPage() {
   }, [router]);
 
   const [isLoading, setIsLoading] = useState(true);
+  const [userId, setUserId] = useState<string | null>(null);
   const [connectedPlatforms, setConnectedPlatforms] = useState<ConnectedPlatform[]>([]);
   const [accountBalance, setAccountBalance] = useState<AccountBalance | null>(null);
   const [appliedTasks, setAppliedTasks] = useState<(TaskDetail & { application?: TaskApplication })[]>([]);
@@ -274,6 +276,7 @@ export default function InfluencerDashboardPage() {
         setIsLoading(true);
         const { data: { user } } = await supabase.auth.getUser();
         if (!user) { router.push("/auth"); return; }
+        setUserId(user.id);
 
         const { data: incomplete, error: incompleteError } = await supabase.rpc('has_incomplete_applications');
         setHasIncompleteTask(!incompleteError && incomplete === true);
@@ -569,7 +572,14 @@ export default function InfluencerDashboardPage() {
                               </div>
                             ) : null}
                             <div className="flex items-center gap-2 w-full">
-                              {!link.unlocked ? (
+                              {typeof link.clicks === "number" && typeof link.shares === "number" && link.clicks >= link.shares ? (
+                                <Button
+                                  className="w-full text-xs h-8 font-semibold text-gray-400 bg-gray-100 border border-gray-200 cursor-not-allowed flex items-center justify-center gap-1.5 transition-all shadow-none"
+                                  disabled
+                                >
+                                  Campaign Full
+                                </Button>
+                              ) : !link.unlocked ? (
                                 <UnlockButtonWithCountdown
                                   linkId={link.id}
                                   nextUnlockAt={link.nextUnlockAt}
@@ -697,6 +707,13 @@ export default function InfluencerDashboardPage() {
           </footer>
         </main>
       </div>
+      {userId && (
+        <GiftBonusModal
+          userId={userId}
+          totalEarning={accountBalance?.total_earning ?? 0}
+          onClaimSuccess={(newBalance) => setAccountBalance(newBalance)}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "@/components/ui/sonner";
+import { Analytics } from "@vercel/analytics/next";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -40,6 +41,7 @@ export default function RootLayout({
       <body className={inter.className} suppressHydrationWarning>
         {children}
         <Toaster />
+        <Analytics />
       </body>
     </html>
   );

--- a/src/components/dashboard/gift-bonus-modal.tsx
+++ b/src/components/dashboard/gift-bonus-modal.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Gift, Sparkles, X, CheckCircle, Wallet } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+
+interface GiftBonusModalProps {
+  userId: string;
+  totalEarning: number;
+  onClaimSuccess: (updatedBalance: any) => void;
+}
+
+export function GiftBonusModal({ userId, totalEarning, onClaimSuccess }: GiftBonusModalProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isClaiming, setIsClaiming] = useState(false);
+  const [isClaimed, setIsClaimed] = useState(false);
+  const [showConfetti, setShowConfetti] = useState(false);
+  const [particles, setParticles] = useState<Array<{ id: number; color: string; left: string; angle: string; delay: string; duration: string }>>([]);
+
+  const PINK = "#C8185A";
+
+  useEffect(() => {
+    if (!userId) return;
+
+    // Check if they already have earnings or have claimed in this session/local storage
+    const localClaimed = localStorage.getItem(`claimed_bonus_${userId}`);
+    if (totalEarning === 0 && !localClaimed) {
+      // Show the modal after a small delay on initial dashboard load
+      const timer = setTimeout(() => {
+        setIsOpen(true);
+      }, 1500);
+      return () => clearTimeout(timer);
+    }
+  }, [userId, totalEarning]);
+
+  // Generate particles for confetti effect
+  const generateParticles = () => {
+    const colors = ["#C8185A", "#EC4899", "#3B82F6", "#10B981", "#F59E0B", "#8B5CF6"];
+    const newParticles = Array.from({ length: 60 }).map((_, i) => ({
+      id: i,
+      color: colors[Math.floor(Math.random() * colors.length)],
+      left: `${Math.random() * 100}%`,
+      angle: `${Math.random() * 360}deg`,
+      delay: `${Math.random() * 0.5}s`,
+      duration: `${1.5 + Math.random() * 1.5}s`
+    }));
+    setParticles(newParticles);
+  };
+
+  const handleClaim = async () => {
+    try {
+      setIsClaiming(true);
+      const res = await fetch("/api/influencer/claim-bonus", {
+        method: "POST"
+      });
+      const data = await res.json();
+      
+      if (!res.ok) {
+        throw new Error(data.error || "Failed to claim bonus");
+      }
+
+      setIsClaimed(true);
+      setShowConfetti(true);
+      generateParticles();
+      
+      // Save to local storage to prevent showing it again
+      localStorage.setItem(`claimed_bonus_${userId}`, "true");
+
+      toast.success("Welcome bonus claimed successfully!");
+      
+      // Update parent balance state
+      if (data.balance) {
+        onClaimSuccess(data.balance);
+      }
+
+      // Close modal after some seconds showing the success and confetti animation
+      setTimeout(() => {
+        setIsOpen(false);
+      }, 4000);
+    } catch (err: any) {
+      console.error(err);
+      toast.error(err.message || "Something went wrong.");
+      setIsClaiming(false);
+    }
+  };
+
+  const handleClose = () => {
+    // Save to local storage even if closed, to avoid annoying the user repeatedly in the same session,
+    // but they can still claim it on next reload if they haven't actually claimed it yet.
+    setIsOpen(false);
+  };
+
+  return (
+    <>
+      <style>{`
+        @keyframes float-up-particle {
+          0% {
+            transform: translateY(100vh) rotate(0deg) scale(0);
+            opacity: 0;
+          }
+          15% {
+            opacity: 1;
+            transform: translateY(50vh) rotate(180deg) scale(1.2);
+          }
+          100% {
+            transform: translateY(-10vh) rotate(720deg) scale(0.6);
+            opacity: 0;
+          }
+        }
+        .confetti-p {
+          position: fixed;
+          bottom: -20px;
+          width: 10px;
+          height: 10px;
+          border-radius: 2px;
+          pointer-events: none;
+          z-index: 9999;
+          animation: float-up-particle linear forwards;
+        }
+      `}</style>
+
+      {/* Confetti Container */}
+      {showConfetti && (
+        <div className="fixed inset-0 pointer-events-none z-[9999] overflow-hidden">
+          {particles.map((p) => (
+            <div
+              key={p.id}
+              className="confetti-p"
+              style={{
+                left: p.left,
+                backgroundColor: p.color,
+                transform: `rotate(${p.angle})`,
+                animationDelay: p.delay,
+                animationDuration: p.duration
+              }}
+            />
+          ))}
+        </div>
+      )}
+
+      <AnimatePresence>
+        {isOpen && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+            {/* Backdrop */}
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              onClick={isClaimed ? undefined : handleClose}
+              className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            />
+
+            {/* Modal Content */}
+            <motion.div
+              initial={{ opacity: 0, scale: 0.9, y: 20 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.9, y: 20 }}
+              transition={{ type: "spring", duration: 0.5 }}
+              className="relative w-full max-w-sm overflow-hidden rounded-2xl bg-white p-6 text-center shadow-2xl border border-gray-150 z-10"
+            >
+              {/* Close Button */}
+              {!isClaimed && (
+                <button
+                  onClick={handleClose}
+                  className="absolute right-4 top-4 rounded-full p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              )}
+
+              {/* Gift Content States */}
+              <AnimatePresence mode="wait">
+                {!isClaimed ? (
+                  <motion.div
+                    key="unclaimed"
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -10 }}
+                    className="flex flex-col items-center"
+                  >
+                    {/* Bouncing Gift Icon */}
+                    <motion.div
+                      animate={{ 
+                        y: [0, -10, 0],
+                        rotate: [0, -3, 3, -3, 3, 0]
+                      }}
+                      transition={{ 
+                        y: { repeat: Infinity, duration: 2, ease: "easeInOut" },
+                        rotate: { repeat: Infinity, duration: 2, ease: "easeInOut", delay: 0.2 }
+                      }}
+                      className="relative flex h-20 w-20 items-center justify-center rounded-2xl bg-pink-50 mb-4"
+                    >
+                      <Gift className="h-10 w-10" style={{ color: PINK }} />
+                      <Sparkles className="absolute -top-1.5 -right-1.5 h-5 w-5 text-amber-500 animate-pulse" />
+                      <Sparkles className="absolute -bottom-1 -left-1 h-4 w-4 text-amber-400 animate-pulse delay-75" />
+                    </motion.div>
+
+                    <h3 className="text-xl font-bold text-gray-900 mb-2">Welcome to BrandSync!</h3>
+                    <p className="text-sm text-gray-500 mb-6 px-2">
+                      Here is a special welcome gift to start your journey. Claim your free $1.00 USD sign-up bonus now!
+                    </p>
+
+                    {/* Reward Card */}
+                    <div className="w-full bg-pink-50/50 rounded-xl border border-pink-100 p-4 mb-6 flex items-center justify-center gap-3">
+                      <div className="h-10 w-10 rounded-lg bg-pink-100 flex items-center justify-center">
+                        <Wallet className="h-5 w-5" style={{ color: PINK }} />
+                      </div>
+                      <div className="text-left">
+                        <p className="text-xs text-pink-600 font-semibold uppercase tracking-wide">Signup Bonus</p>
+                        <p className="text-xl font-bold text-gray-900">$1.00 USD <span className="text-xs text-gray-400 font-normal">(LKR 295.00)</span></p>
+                      </div>
+                    </div>
+
+                    <Button
+                      onClick={handleClaim}
+                      disabled={isClaiming}
+                      className="w-full h-10 font-bold text-white shadow-md hover:shadow-lg transition-all"
+                      style={{ background: PINK }}
+                    >
+                      {isClaiming ? (
+                        <>
+                          <div className="mr-2 h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+                          Claiming Bonus...
+                        </>
+                      ) : (
+                        "Claim Bonus 🎁"
+                      )}
+                    </Button>
+                  </motion.div>
+                ) : (
+                  <motion.div
+                    key="claimed"
+                    initial={{ opacity: 0, scale: 0.8 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    className="flex flex-col items-center py-4"
+                  >
+                    <motion.div
+                      initial={{ scale: 0 }}
+                      animate={{ scale: [0, 1.2, 1] }}
+                      transition={{ type: "spring", stiffness: 200, damping: 10 }}
+                      className="flex h-16 w-16 items-center justify-center rounded-full bg-emerald-100 mb-4"
+                    >
+                      <CheckCircle className="h-10 w-10 text-emerald-600" />
+                    </motion.div>
+
+                    <h3 className="text-xl font-bold text-gray-900 mb-1">Congratulations!</h3>
+                    <p className="text-sm text-emerald-600 font-semibold mb-2">+$1.00 USD (LKR 295.00) Credited</p>
+                    <p className="text-xs text-gray-400 max-w-[200px] leading-relaxed">
+                      Your welcome gift has been added to your available balance. Have fun monetizing!
+                    </p>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </motion.div>
+          </div>
+        )}
+      </AnimatePresence>
+    </>
+  );
+}


### PR DESCRIPTION
Introduce an influencer signup bonus flow and stricter campaign limit checks. Adds a new claim API (/api/influencer/claim-bonus) that credits a $1 USD (LKR-converted) signup bonus by inserting/updating account_balance for influencers. Adds a GiftBonusModal component and integrates it into the influencer dashboard to prompt eligible users (with localStorage guarding and confetti UI). Enforces campaign capacity: checks total clicks vs shares in brandsync influencer-token and go/click routes and returns/blocks when campaigns are full; also updates UI to show a disabled "Campaign Full" button. Also mounts Vercel Analytics in the root layout and bumps @vercel/analytics in package.json.