### PR TITLE
Increase influencer signup bonus to $3 and update UI

### DIFF
--- a/src/app/api/influencer/claim-bonus/route.ts
+++ b/src/app/api/influencer/claim-bonus/route.ts
@@ -106,7 +106,7 @@ export async function POST(request: Request) {
       .from('influencer_signup_bonuses')
       .insert({
         user_id: user.id,
-        amount: 1.00
+        amount: 3.00
       });
 
     if (insertBonusErr) {
@@ -127,7 +127,7 @@ export async function POST(request: Request) {
     }
 
     const lkrPerUsd = Number(process.env.NEXT_PUBLIC_LKR_PER_USD || process.env.LKR_PER_USD || 295);
-    const bonusLKR = 1 * lkrPerUsd;
+    const bonusLKR = 3 * lkrPerUsd;
 
     let updatedBalance;
     if (currentBalance) {

--- a/src/components/dashboard/gift-bonus-modal.tsx
+++ b/src/components/dashboard/gift-bonus-modal.tsx
@@ -199,7 +199,7 @@ export function GiftBonusModal({ userId, isClaimedInDb, onClaimSuccess }: GiftBo
 
                     <h3 className="text-xl font-bold text-gray-900 mb-2">Welcome to BrandSync!</h3>
                     <p className="text-sm text-gray-500 mb-6 px-2">
-                      Here is a special welcome gift to start your journey. Claim your free $1.00 USD sign-up bonus now!
+                      Here is a special welcome gift to start your journey. Claim your free $3.00 USD sign-up bonus now!
                     </p>
 
                     {/* Reward Card */}
@@ -209,7 +209,7 @@ export function GiftBonusModal({ userId, isClaimedInDb, onClaimSuccess }: GiftBo
                       </div>
                       <div className="text-left">
                         <p className="text-xs text-pink-600 font-semibold uppercase tracking-wide">Signup Bonus</p>
-                        <p className="text-xl font-bold text-gray-900">$1.00 USD <span className="text-xs text-gray-400 font-normal"></span></p>
+                        <p className="text-xl font-bold text-gray-900">$3.00 USD</p>
                       </div>
                     </div>
 
@@ -246,7 +246,7 @@ export function GiftBonusModal({ userId, isClaimedInDb, onClaimSuccess }: GiftBo
                     </motion.div>
 
                     <h3 className="text-xl font-bold text-gray-900 mb-1">Congratulations!</h3>
-                    <p className="text-sm text-emerald-600 font-semibold mb-2">+$1.00 USD Credited</p>
+                    <p className="text-sm text-emerald-600 font-semibold mb-2">+$3.00 USD Credited</p>
                     <p className="text-xs text-gray-400 max-w-[200px] leading-relaxed">
                       Your welcome gift has been added to your available balance. Have fun monetizing!
                     </p>


### PR DESCRIPTION
This pull request increases the influencer sign-up bonus from $1.00 USD to $3.00 USD throughout both the backend logic and the user interface. The most important changes are summarized below.

**Backend changes:**

* The bonus amount inserted into the `influencer_signup_bonuses` table is increased from 1.00 to 3.00 (`src/app/api/influencer/claim-bonus/route.ts`).
* The calculation for the bonus in LKR is updated to use 3 times the exchange rate instead of 1 (`src/app/api/influencer/claim-bonus/route.ts`).

**Frontend/UI changes:**

* All user-facing text and displays in `GiftBonusModal` are updated to show a $3.00 USD sign-up bonus instead of $1.00 (`src/components/dashboard/gift-bonus-modal.tsx`) [[1]](diffhunk://#diff-e1666d99e392b6cdcc8ddd23628ffde1a1791325d44aa45ad00c75ac481a57f7L202-R202) [[2]](diffhunk://#diff-e1666d99e392b6cdcc8ddd23628ffde1a1791325d44aa45ad00c75ac481a57f7L212-R212) [[3]](diffhunk://#diff-e1666d99e392b6cdcc8ddd23628ffde1a1791325d44aa45ad00c75ac481a57f7L249-R249).